### PR TITLE
Fix Prisma datasource to use DATABASE_URL environment variable

### DIFF
--- a/prisma/mysql-schema.prisma
+++ b/prisma/mysql-schema.prisma
@@ -10,7 +10,7 @@ generator client {
 
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_CONNECTION_URI")
+  url      = env("DATABASE_URL")
 }
 
 enum InstanceConnectionStatus {

--- a/prisma/postgresql-schema.prisma
+++ b/prisma/postgresql-schema.prisma
@@ -10,7 +10,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("DATABASE_CONNECTION_URI")
+  url      = env("DATABASE_URL")
 }
 
 enum InstanceConnectionStatus {


### PR DESCRIPTION
## Problem\nThe Prisma schemas were hardcoded to use  environment variable, but Railway's Postgres service provides . This caused authentication failures during migrations.\n\n## Changes\n- Updated  to use  instead of \n- Updated  to use  instead of \n\n## Result\nMigrations will now correctly authenticate with the database using the proper environment variable provided by Railway's database services.

## 📋 Description
<!-- Describe your changes in detail -->

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [ ] Manual testing completed
- [ ] Functionality verified in development environment
- [ ] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have manually tested my changes thoroughly
- [ ] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes
<!-- Any additional information, concerns, or questions -->

## Summary by Sourcery

Bug Fixes:
- Fix database authentication failures by switching Prisma MySQL and PostgreSQL datasources to use the DATABASE_URL environment variable.