### PR TITLE
fix(baileys): send mediaUrl in webhook without SAVE_DATA.NEW_MESSAGE

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1542,10 +1542,11 @@ export class BaileysStartupService extends ChannelStartupService {
             }
           }
 
+          let msg: any = null;
           if (this.configService.get<Database>('DATABASE').SAVE_DATA.NEW_MESSAGE) {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { pollUpdates, ...messageData } = messageRaw as any;
-            const msg = await this.prismaRepository.message.create({ data: messageData });
+            msg = await this.prismaRepository.message.create({ data: messageData });
 
             const { remoteJid } = received.key;
             const timestamp = msg.messageTimestamp;
@@ -1573,41 +1574,43 @@ export class BaileysStartupService extends ChannelStartupService {
             } else {
               this.logger.info(`Update readed messages duplicated ignored [avoid deadlock]: ${messageKey}`);
             }
+          }
 
-            if (isMedia) {
-              if (this.configService.get<S3>('S3').ENABLE) {
-                try {
-                  if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
-                    this.logger.warn('Video upload is disabled. Skipping video upload.');
-                    // Skip video upload by returning early from this block
+          if (isMedia) {
+            if (this.configService.get<S3>('S3').ENABLE) {
+              try {
+                if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
+                  this.logger.warn('Video upload is disabled. Skipping video upload.');
+                  // Skip video upload by returning early from this block
+                  return;
+                }
+
+                const message: any = received;
+
+                // Verificação adicional para garantir que há conteúdo de mídia real
+                const hasRealMedia = this.hasValidMediaContent(message);
+
+                if (!hasRealMedia) {
+                  this.logger.warn('Message detected as media but contains no valid media content');
+                } else {
+                  const media = await this.getBase64FromMediaMessage({ message }, true);
+
+                  if (!media) {
+                    this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
                     return;
                   }
 
-                  const message: any = received;
+                  const { buffer, mediaType, fileName, size } = media;
+                  const mimetype = mimeTypes.lookup(fileName).toString();
+                  const fullName = join(
+                    `${this.instance.id}`,
+                    received.key.remoteJid,
+                    mediaType,
+                    `${Date.now()}_${fileName}`,
+                  );
+                  await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
 
-                  // Verificação adicional para garantir que há conteúdo de mídia real
-                  const hasRealMedia = this.hasValidMediaContent(message);
-
-                  if (!hasRealMedia) {
-                    this.logger.warn('Message detected as media but contains no valid media content');
-                  } else {
-                    const media = await this.getBase64FromMediaMessage({ message }, true);
-
-                    if (!media) {
-                      this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
-                      return;
-                    }
-
-                    const { buffer, mediaType, fileName, size } = media;
-                    const mimetype = mimeTypes.lookup(fileName).toString();
-                    const fullName = join(
-                      `${this.instance.id}`,
-                      received.key.remoteJid,
-                      mediaType,
-                      `${Date.now()}_${fileName}`,
-                    );
-                    await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
-
+                  if (msg?.id) {
                     await this.prismaRepository.media.create({
                       data: {
                         messageId: msg.id,
@@ -1617,16 +1620,18 @@ export class BaileysStartupService extends ChannelStartupService {
                         mimetype,
                       },
                     });
+                  }
 
-                    const mediaUrl = await s3Service.getObjectUrl(fullName);
+                  const mediaUrl = await s3Service.getObjectUrl(fullName);
 
-                    (messageRaw.message as any).mediaUrl = mediaUrl;
+                  (messageRaw.message as any).mediaUrl = mediaUrl;
 
+                  if (msg?.id) {
                     await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
                   }
-                } catch (error) {
-                  this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);
                 }
+              } catch (error) {
+                this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);
               }
             }
           }
@@ -1674,7 +1679,6 @@ export class BaileysStartupService extends ChannelStartupService {
 
             messageRaw.key.addressingMode = 'pn';
           }
-          console.log(messageRaw);
 
           this.sendDataWebhook(Events.MESSAGES_UPSERT, messageRaw);
 

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1581,6 +1581,7 @@ export class BaileysStartupService extends ChannelStartupService {
               try {
                 if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
                   this.logger.warn('Video upload is disabled. Skipping video upload.');
+                  return;
                 } else {
                   const message: any = received;
 
@@ -1594,6 +1595,7 @@ export class BaileysStartupService extends ChannelStartupService {
 
                     if (!media) {
                       this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
+                      return;
                     } else {
                       const { buffer, mediaType, fileName, size } = media;
                       const mimetype = mimeTypes.lookup(fileName).toString();

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1542,7 +1542,7 @@ export class BaileysStartupService extends ChannelStartupService {
             }
           }
 
-          let msg: any = null;
+          let msg: Message | null = null;
           if (this.configService.get<Database>('DATABASE').SAVE_DATA.NEW_MESSAGE) {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { pollUpdates, ...messageData } = messageRaw as any;
@@ -1581,53 +1581,50 @@ export class BaileysStartupService extends ChannelStartupService {
               try {
                 if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
                   this.logger.warn('Video upload is disabled. Skipping video upload.');
-                  // Skip video upload by returning early from this block
-                  return;
-                }
-
-                const message: any = received;
-
-                // Verificação adicional para garantir que há conteúdo de mídia real
-                const hasRealMedia = this.hasValidMediaContent(message);
-
-                if (!hasRealMedia) {
-                  this.logger.warn('Message detected as media but contains no valid media content');
                 } else {
-                  const media = await this.getBase64FromMediaMessage({ message }, true);
+                  const message: any = received;
 
-                  if (!media) {
-                    this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
-                    return;
-                  }
+                  // Verificação adicional para garantir que há conteúdo de mídia real
+                  const hasRealMedia = this.hasValidMediaContent(message);
 
-                  const { buffer, mediaType, fileName, size } = media;
-                  const mimetype = mimeTypes.lookup(fileName).toString();
-                  const fullName = join(
-                    `${this.instance.id}`,
-                    received.key.remoteJid,
-                    mediaType,
-                    `${Date.now()}_${fileName}`,
-                  );
-                  await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
+                  if (!hasRealMedia) {
+                    this.logger.warn('Message detected as media but contains no valid media content');
+                  } else {
+                    const media = await this.getBase64FromMediaMessage({ message }, true);
 
-                  if (msg?.id) {
-                    await this.prismaRepository.media.create({
-                      data: {
-                        messageId: msg.id,
-                        instanceId: this.instanceId,
-                        type: mediaType,
-                        fileName: fullName,
-                        mimetype,
-                      },
-                    });
-                  }
+                    if (!media) {
+                      this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
+                    } else {
+                      const { buffer, mediaType, fileName, size } = media;
+                      const mimetype = mimeTypes.lookup(fileName).toString();
+                      const fullName = join(
+                        `${this.instance.id}`,
+                        received.key.remoteJid,
+                        mediaType,
+                        `${Date.now()}_${fileName}`,
+                      );
+                      await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
 
-                  const mediaUrl = await s3Service.getObjectUrl(fullName);
+                      if (msg?.id) {
+                        await this.prismaRepository.media.create({
+                          data: {
+                            messageId: msg.id,
+                            instanceId: this.instanceId,
+                            type: mediaType,
+                            fileName: fullName,
+                            mimetype,
+                          },
+                        });
+                      }
 
-                  (messageRaw.message as any).mediaUrl = mediaUrl;
+                      const mediaUrl = await s3Service.getObjectUrl(fullName);
 
-                  if (msg?.id) {
-                    await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
+                      (messageRaw.message as any).mediaUrl = mediaUrl;
+
+                      if (msg?.id) {
+                        await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
+                      }
+                    }
                   }
                 }
               } catch (error) {


### PR DESCRIPTION
## 📋 Description
Fixes sending mediaUrl via webhook even when DATABASE.SAVE_DATA.NEW_MESSAGE is not enabled.

## 🔗 Related Issue
<!-- Link to the issue this PR addresses -->
Closes #(issue_number)

## 🧪 Type of Change
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing
<!-- Describe the testing you performed to verify your changes -->
- [x] Manual testing completed
- [ ] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## ✅ Checklist
<!-- Mark with an `x` all the checkboxes that apply -->
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## Summary by Sourcery

Bug Fixes:
- Fix missing mediaUrl in webhooks when DATABASE.SAVE_DATA.NEW_MESSAGE is disabled.