### PR TITLE
feat(cloud-api): support CTA URL buttons in sendButtons

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -1175,15 +1175,17 @@ export class BusinessStartupService extends ChannelStartupService {
                 action: {
                   name: 'cta_url',
                   parameters: {
-                    display_text: ctaUrlButton.displayText,
+                    display_text: ctaUrlButton.displayText ?? ctaUrlButton.url,
                     url: ctaUrlButton.url,
                   },
                 },
               },
             };
-            quoted ? (content.context = { message_id: quoted.id }) : content;
+            if (quoted) {
+              content.context = { message_id: quoted.id };
+            }
             message = {
-              conversation: `${message['text'] || 'Select'}\n▶️ ${ctaUrlButton.displayText}: ${ctaUrlButton.url}\n`,
+              conversation: `${message['text'] || 'Select'}\n▶️ ${ctaUrlButton.displayText ?? ctaUrlButton.url}: ${ctaUrlButton.url}\n`,
             };
             return await this.post(content, 'messages');
           }
@@ -1565,7 +1567,7 @@ export class BusinessStartupService extends ChannelStartupService {
       {
         text: !embeddedMedia?.mediaKey ? data.title : undefined,
         buttons: data.buttons.map((button) => {
-          if (button.type === 'url') {
+          if (button.type === 'url' && button.url) {
             return {
               type: 'cta_url',
               displayText: button.displayText,

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -1158,6 +1158,35 @@ export class BusinessStartupService extends ChannelStartupService {
           return await this.post(content, 'messages');
         }
         if (message['buttons']) {
+          const ctaUrlButton = message['buttons'].find((button) => button.type === 'cta_url');
+          if (ctaUrlButton) {
+            // WhatsApp Cloud API CTA URL button: a single tappable link button in a
+            // free-form (session) message. It cannot be combined with reply buttons.
+            content = {
+              messaging_product: 'whatsapp',
+              recipient_type: 'individual',
+              to: number.replace(/\D/g, ''),
+              type: 'interactive',
+              interactive: {
+                type: 'cta_url',
+                body: {
+                  text: message['text'] || 'Select',
+                },
+                action: {
+                  name: 'cta_url',
+                  parameters: {
+                    display_text: ctaUrlButton.displayText,
+                    url: ctaUrlButton.url,
+                  },
+                },
+              },
+            };
+            quoted ? (content.context = { message_id: quoted.id }) : content;
+            message = {
+              conversation: `${message['text'] || 'Select'}\n▶️ ${ctaUrlButton.displayText}: ${ctaUrlButton.url}\n`,
+            };
+            return await this.post(content, 'messages');
+          }
           content = {
             messaging_product: 'whatsapp',
             recipient_type: 'individual',
@@ -1176,7 +1205,7 @@ export class BusinessStartupService extends ChannelStartupService {
           quoted ? (content.context = { message_id: quoted.id }) : content;
           let formattedText = '';
           for (const item of message['buttons']) {
-            formattedText += `▶️ ${item.reply?.title}\n`;
+            formattedText += `▶️ ${item.reply?.title ?? item.displayText}\n`;
           }
           message = { conversation: `${message['text'] || 'Select'}\n` + formattedText };
           return await this.post(content, 'messages');
@@ -1536,6 +1565,13 @@ export class BusinessStartupService extends ChannelStartupService {
       {
         text: !embeddedMedia?.mediaKey ? data.title : undefined,
         buttons: data.buttons.map((button) => {
+          if (button.type === 'url') {
+            return {
+              type: 'cta_url',
+              displayText: button.displayText,
+              url: button.url,
+            };
+          }
           return {
             type: 'reply',
             reply: {


### PR DESCRIPTION
## What

Add support for **CTA URL (link) buttons** in `sendButtons` on the Cloud API (WhatsApp Business) channel.

## Why

On the Cloud API channel, `buttonMessage` mapped **every** button to `type: 'reply'`, so sending a button with `type: 'url'` failed at Meta with:

```
interactive.action.buttons.0.reply is required: id  (code 100, OAuthException)
```

This made it impossible to send a link button in a **free-form (session) message**, even though the Cloud API supports it through the interactive [`cta_url`](https://developers.facebook.com/docs/whatsapp/cloud-api/messages/interactive-cta-url-messages/) type. Reported in #1249.

## How

- `buttonMessage` now preserves `type: 'url'` buttons (as a `cta_url` entry) instead of forcing them into the reply shape.
- `sendMessageWithTyping` detects a `cta_url` button and builds an interactive `cta_url` message:
  ```jsonc
  "interactive": {
    "type": "cta_url",
    "body": { "text": "<title>" },
    "action": { "name": "cta_url", "parameters": { "display_text": "<text>", "url": "<url>" } }
  }
  ```
  Per the Cloud API, `cta_url` allows a **single** link button and cannot be combined with reply buttons, so the first url button wins.
- The reply-button path is unchanged.
- The internal text echo falls back to the button `displayText`, so cta_url buttons no longer render as `undefined`.

## Request example

```jsonc
POST /message/sendButtons/{instance}
{
  "number": "5599999999999",
  "title": "Your gallery is ready!",
  "buttons": [
    { "type": "url", "displayText": "Open gallery", "url": "https://example.com/g/abc" }
  ]
}
```

## Testing

Tested against a live WhatsApp Business (Cloud API) number: the button is accepted by Meta (returns a `wamid`) and renders as a tappable link button inside the 24h session window. Existing reply-button sends are unaffected.

Closes #1249

## Summary by Sourcery

Add support for CTA URL buttons in WhatsApp Cloud API sendButtons so link buttons can be sent as interactive messages in session conversations.

New Features:
- Allow sending CTA URL (link) buttons via sendButtons on the WhatsApp Cloud API channel by mapping URL buttons to interactive cta_url messages.

Enhancements:
- Preserve URL-type buttons instead of coercing them into reply buttons in buttonMessage for the Cloud API channel.
- Improve internal text echo for buttons by falling back to the button displayText when reply title is absent, avoiding undefined labels.