### PR TITLE
fix(docker): restore the patches/ directory the builder copies

### DIFF
--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,8 @@
+# patches/
+
+`patch-package` patches for third-party dependencies. They are applied by the
+`postinstall` hook (`package.json`) and re-applied inside the Docker builder,
+which copies this directory before `npm ci` (`COPY ./patches ./patches`).
+
+Keep this directory tracked even when there is no patch: removing it breaks the
+Docker build, since the `COPY` above cannot resolve a path that does not exist.


### PR DESCRIPTION
A imagem Docker da `develop` não builda desde **15/06** — todo push falha no passo `Build and push`:

```
ERROR: failed to build: failed to solve: failed to compute cache key:
failed to calculate checksum of ref ...: "/patches": not found
```

Exemplo: [run 29290412854](https://github.com/evolution-foundation/evolution-api/actions/runs/29290412854/job/86952518892).

## Causa

`dd552c77` (PR #2575, *chore(deps): atualização agressiva — Baileys rc13…*) subiu o Baileys para `7.0.0-rc13` e removeu o patch que já não se aplicava (`patches/baileys+7.0.0-rc.6.patch`). Era o único arquivo do diretório, então `patches/` deixou de existir no repositório — mas o `Dockerfile:15` continua com `COPY ./patches ./patches` antes do `npm ci`, e o buildkit não resolve um path que não existe no contexto.

O workflow `publish_docker_image_homolog.yml` teve o último verde em 10/06 e falha em todos os pushes desde o merge do #2575. (Não é regressão do #2636; a quebra de `npm run build` do mesmo commit foi tratada em EVO-2097 — o build da imagem ficou de fora.)

## Correção

Volta a versionar `patches/` (via um README que explica a dependência). `patch-package` continua ligado no `postinstall` e na devDep, então:

- o `COPY` resolve e a imagem volta a buildar;
- um patch futuro passa a funcionar só adicionando o `.patch` no diretório.

A alternativa — apagar o `COPY` do Dockerfile — deixaria uma armadilha: quem adicionasse um patch depois teria a imagem ignorando ele em silêncio.

## Validação

- A sequência de `COPY` do Dockerfile (incluindo `./patches`) resolve contra o contexto real de build (reproduzida em build isolado). Antes: `"/patches": not found`.
- `npx patch-package` com o diretório sem nenhum `.patch` sai `0` (`No patch files found`) — o `postinstall` e o `RUN npx patch-package` do builder seguem no-op, sem quebrar o `npm ci`.