### PR TITLE
fix(whatsapp): restore reply/quote contextInfo in prepareMessage

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -5155,6 +5155,8 @@ export class BaileysStartupService extends ChannelStartupService {
 
   private prepareMessage(message: WAMessage): Message {
     const keyAny = message.key as any;
+    const contentType = getContentType(message.message);
+    const contentMsg = contentType ? (message.message?.[contentType] as any) : undefined;
     const messageRaw: any = {
       key: {
         ...message.key,
@@ -5167,14 +5169,20 @@ export class BaileysStartupService extends ChannelStartupService {
           ? 'Você'
           : message?.participant || (message.key?.participant ? message.key.participant.split('@')[0] : null)),
       message: this.deserializeMessageBuffers({ ...message.message }),
-      messageType: getContentType(message.message),
+      messageType: contentType,
       messageTimestamp: Long.isLong(message.messageTimestamp)
         ? message.messageTimestamp.toNumber()
         : (message.messageTimestamp as number),
       source: getDevice(keyAny.id),
       instanceId: this.instanceId,
       status: status[message.status],
-      contextInfo: this.deserializeMessageBuffers(message.message?.messageContextInfo),
+      // The quote/reply context lives on the content node (e.g.
+      // extendedTextMessage.contextInfo), not on the top-level
+      // messageContextInfo (which only carries device/encryption metadata).
+      // Reading it from the content node keeps stanzaId/participant/quotedMessage
+      // available after the extendedTextMessage node is flattened below — this
+      // is how it worked through v2.3.7 and what downstream reply handling expects.
+      contextInfo: this.deserializeMessageBuffers(contentMsg?.contextInfo ?? message.message?.messageContextInfo),
     };
 
     if (!messageRaw.status && message.key.fromMe === false) {


### PR DESCRIPTION
## Problem

Inbound (and outbound) **text replies lose their quote/reply context**. A message that quotes another arrives at the `messages.upsert` webhook — and is persisted, and returned by `chat/findMessages` — as `messageType: "conversation"` with **no `contextInfo.quotedMessage`, no `stanzaId`, no `participant`**. There is no way for any integration (Chatwoot, n8n, custom webhooks) to link a reply to the message it quotes.

This matches the long-standing report in #2078 ("Reply/Quote breaks on 2.3.3+") and is part of the `@lid` meta #1872, but the actual cause is a small regression in `prepareMessage`.

## Root cause

In `BaileysStartupService.prepareMessage`, the message `contextInfo` is sourced from the **wrong field**:

```ts
contextInfo: this.deserializeMessageBuffers(message.message?.messageContextInfo),
```

`message.message.messageContextInfo` only carries device-list / encryption metadata (`threadId`, `deviceListMetadata`, `messageSecret`, `limitSharingV2`) — it **never** contains the quote. The reply context (`stanzaId`, `participant`, `quotedMessage`) lives on the **content node**, e.g. `message.message.extendedTextMessage.contextInfo`.

A few lines below, the `extendedTextMessage` node is flattened into `conversation` and **deleted**:

```ts
if (messageRaw.message.extendedTextMessage) {
  messageRaw.messageType = 'conversation';
  messageRaw.message.conversation = messageRaw.message.extendedTextMessage.text;
  delete messageRaw.message.extendedTextMessage;
}
```

So the quote is dropped entirely, and the `messageRaw.contextInfo.quotedMessage` handling right after it becomes **dead code** (it can never see a `quotedMessage`).

## Regression window

Every stable release sourced `contextInfo` from the content node and quotes worked:

- **2.3.2 / 2.3.3 / 2.3.7** → `contextInfo: contentMsg?.contextInfo` (with `contentMsg = message.message[getContentType(...)]`)
- **develop / homolog** → `contextInfo: message.message?.messageContextInfo` ❌

This is not a Baileys issue: 2.3.7 already runs Baileys `7.0.0-rc.9` and delivers the quote correctly. Only the source field changed.

## Fix

Restore the content-node source, with a fallback to `messageContextInfo` so nothing is lost, and reuse the already-computed content type. The `extendedTextMessage -> conversation` normalization is intentionally kept unchanged.

```ts
const contentType = getContentType(message.message);
const contentMsg = contentType ? (message.message?.[contentType] as any) : undefined;
// ...
contextInfo: this.deserializeMessageBuffers(contentMsg?.contextInfo ?? message.message?.messageContextInfo),
```

After the fix, `messages.upsert` again exposes `contextInfo.stanzaId` / `participant` / `quotedMessage` for replies, and the downstream `quotedMessage` handling in `prepareMessage` works again. `messageContextInfo` remains available under `messageRaw.message.messageContextInfo`.

Refs #2078, #1872.

## Summary by Sourcery

Bug Fixes:
- Preserve reply/quote contextInfo (stanzaId, participant, quotedMessage) for WhatsApp messages by sourcing it from the message content node instead of the top-level messageContextInfo.