### PR TITLE
fix: Chatwoot integration drops templateMessage, conversation never created

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1858,6 +1858,7 @@ export class ChatwootService {
         msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
         msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
         msg?.message?.viewOnceMessageV2?.message?.audioMessage?.url,
+      templateMessage: msg.templateMessage?.hydratedTemplate?.hydratedContentText,
     };
 
     return types;

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1858,7 +1858,7 @@ export class ChatwootService {
         msg?.message?.viewOnceMessageV2?.message?.imageMessage?.url ||
         msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
         msg?.message?.viewOnceMessageV2?.message?.audioMessage?.url,
-      templateMessage: msg.templateMessage?.hydratedTemplate?.hydratedContentText,
+      templateMessage: msg?.templateMessage?.hydratedTemplate?.hydratedContentText,
     };
 
     return types;

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1866,6 +1866,8 @@ export class ChatwootService {
       albumMessage: msg?.albumMessage
         ? `[álbum: ${msg.albumMessage.expectedImageCount ?? 0} foto(s), ${msg.albumMessage.expectedVideoCount ?? 0} vídeo(s)]`
         : undefined,
+      pollCreationMessage: msg?.pollCreationMessage?.name,
+      groupInviteMessage: msg?.groupInviteMessage?.caption || msg?.groupInviteMessage?.groupName,
     };
 
     return types;

--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -1859,6 +1859,13 @@ export class ChatwootService {
         msg?.message?.viewOnceMessageV2?.message?.videoMessage?.url ||
         msg?.message?.viewOnceMessageV2?.message?.audioMessage?.url,
       templateMessage: msg?.templateMessage?.hydratedTemplate?.hydratedContentText,
+      buttonsMessage: msg?.buttonsMessage?.contentText,
+      interactiveMessage: msg?.interactiveMessage?.body?.text,
+      // AlbumMessage carries no text (WAProto: only expectedImageCount/expectedVideoCount) —
+      // the photos/videos arrive as separate associatedChildMessage-wrapped messages.
+      albumMessage: msg?.albumMessage
+        ? `[álbum: ${msg.albumMessage.expectedImageCount ?? 0} foto(s), ${msg.albumMessage.expectedVideoCount ?? 0} vídeo(s)]`
+        : undefined,
     };
 
     return types;
@@ -2105,6 +2112,12 @@ export class ChatwootService {
   }
 
   public getConversationMessage(msg: any) {
+    // associatedChildMessage (WAProto: FutureProofMessage) just wraps a real embedded
+    // message (e.g. an album's individual photo/video) — unwrap and extract from that.
+    if (msg?.associatedChildMessage?.message) {
+      return this.getConversationMessage(msg.associatedChildMessage.message);
+    }
+
     const types = this.getTypeMessage(msg);
 
     const messageContent = this.getMessageContent(types);
@@ -2193,8 +2206,22 @@ export class ChatwootService {
           };
         }
 
+        // WhatsApp-internal placeholder (e.g. device-linking mask) — never real user content.
+        if (body.message?.placeholderMessage) {
+          this.logger.verbose('Ignoring internal WhatsApp placeholderMessage (not a user message)');
+          return;
+        }
+
+        // Encrypted edit/event payload targeting an existing message (WAProto SecretEncryptedMessage:
+        // EVENT_EDIT/MESSAGE_EDIT) — not new displayable content. Decrypting and applying it as an
+        // edit isn't implemented; skip explicitly so it isn't logged as a dropped/lost message.
+        if (body.message?.secretEncryptedMessage) {
+          this.logger.verbose('Ignoring secretEncryptedMessage (message edit/event payload, not new content)');
+          return;
+        }
+
         const originalMessage = await this.getConversationMessage(body.message);
-        const bodyMessage = originalMessage
+        let bodyMessage = originalMessage
           ? originalMessage
               .replaceAll(/\*((?!\s)([^\n*]+?)(?<!\s))\*/g, '**$1**')
               .replaceAll(/_((?!\s)([^\n_]+?)(?<!\s))_/g, '*$1*')
@@ -2230,8 +2257,20 @@ export class ChatwootService {
         const isInteractiveButtonMessage = this.isInteractiveButtonMessage(body.messageType, body.message);
 
         if (!bodyMessage && !isMedia && !reactionMessage && !isInteractiveButtonMessage) {
-          this.logger.warn('no body message found');
-          return;
+          // Degrade gracefully instead of silently dropping the conversation: any message type
+          // with no dedicated extractor above still gets a placeholder body, and the actual type
+          // is logged so it's discoverable instead of only visible by reconciling two databases.
+          const detectedType = Object.keys(body.message ?? {}).find((key) => body.message[key] !== undefined);
+
+          if (!detectedType) {
+            this.logger.warn('no body message found (empty message payload)');
+            return;
+          }
+
+          this.logger.warn(
+            `no content extractor for message type "${detectedType}" — creating conversation with a placeholder body instead of dropping it`,
+          );
+          bodyMessage = `[mensagem não suportada: ${detectedType}]`;
         }
 
         const getConversation = await this.createConversation(instance, body);


### PR DESCRIPTION
`getTypeMessage()` doesn't have a case for `templateMessage`, so when a
contact's first message arrives as a WhatsApp Business template (common
for B2B outreach sent via WhatsApp Business Platform), no content is
extracted, `eventWhatsapp` logs `"no body message found"` and returns
before ever calling `createConversation` — the conversation is silently
dropped, and only gets created later if/when a normal-type message
follows (e.g. a reply).

This adds `hydratedTemplate.hydratedContentText` extraction, mirroring
how `templateMessage` is already handled in the *other*
`getContentMessage()` fallback path a few lines below, which just isn't
used on this ingestion path.

Fixes the `templateMessage` item tracked in #2014.
Duplicate of the (closed) #2500.

Tested against a real production instance: reproduced the exact
`"no body message found"` log with a live inbound `templateMessage`,
applied this one-line fix, confirmed the conversation now gets created
correctly (as `incoming`) instead of being dropped.

## Summary by Sourcery

Bug Fixes:
- Extract content from WhatsApp templateMessage hydratedTemplate.hydratedContentText to avoid dropping conversations when the first inbound message is a template.