### PR TITLE
fix(baileys): expose delivery receipts for group messages

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2163,6 +2163,19 @@ export class BaileysStartupService extends ChannelStartupService {
               const remotesJidMap: Record<string, number> = {};
 
               for (const event of payload) {
+                // Group receipts arrive here instead of `messages.update`, with
+                // delivery carried by `receiptTimestamp` and read by `readTimestamp`
+                // (Baileys sets exactly one of them per event). Only the latter was
+                // consumed, so group delivery never reached the webhook.
+                this.sendDataWebhook(Events.MESSAGES_UPDATE, {
+                  keyId: event.key.id,
+                  remoteJid: event.key.remoteJid,
+                  fromMe: event.key.fromMe,
+                  participant: event.receipt.userJid,
+                  status: typeof event.receipt.receiptTimestamp === 'number' ? 'DELIVERY_ACK' : 'READ',
+                  instanceId: this.instanceId,
+                });
+
                 if (typeof event.key.remoteJid === 'string' && typeof event.receipt.readTimestamp === 'number') {
                   remotesJidMap[event.key.remoteJid] = event.receipt.readTimestamp;
                 }


### PR DESCRIPTION
## Problem

Delivery confirmation for **group messages** never reaches the webhook.

Individual chats confirm normally (`SERVER_ACK` → `DELIVERY_ACK` → `READ`), but group messages produce **no event at all** — even though WhatsApp does send the receipt and Baileys does receive it, one per participant.

## Root cause

Baileys routes receipts for group messages to `message-receipt.update` instead of `messages.update` (`handleReceipt` in `messages-recv.ts`):

```js
if (isJidGroup(remoteJid) || isJidStatusBroadcast(remoteJid)) {
    const updateKey = status === DELIVERY_ACK ? 'receiptTimestamp' : 'readTimestamp';
    ev.emit('message-receipt.update', ...)
}
```

Note that **delivery arrives as `receiptTimestamp`**, while read arrives as `readTimestamp`. The handler for that event consumes only `readTimestamp` and never calls `sendDataWebhook`, so the delivery signal is silently dropped.

## Evidence

Measured on 2.3.7 with `LOG_BAILEYS=debug`. A single message sent to a 3-participant group produced four receipt stanzas (identifiers redacted):

```json
{"recv":{"tag":"receipt","attrs":{"from":"<group>@g.us","id":"<msg-id>","participant":"<user-a>:11@lid"}}}
{"recv":{"tag":"receipt","attrs":{"from":"<group>@g.us","id":"<msg-id>","participant":"<user-b>:6@lid"}}}
{"recv":{"tag":"receipt","attrs":{"from":"<group>@g.us","id":"<msg-id>","participant":"<user-b>@lid"}}}
{"recv":{"tag":"receipt","attrs":{"from":"<group>@g.us","type":"read","id":"<msg-id>","participant":"<user-a>:11@lid"}}}
```

Webhook calls in the same window: **zero**.

With this patch applied, the same test produces four `MESSAGES_UPDATE` events with `participant` populated and status `DELIVERY_ACK` / `READ`.

## Approach

Emits `MESSAGES_UPDATE` using the **same flat payload** as the individual-chat branch, so that:

- no new event type is needed in the `Events` enum or in the per-integration schemas (webhook, RabbitMQ, NATS, SQS, Kafka, Pusher);
- existing consumers keep working — `participant` is already part of the status schema;
- the existing `readTimestamp` handling is left untouched.

## Notes

- Running in production since 2026-08-05, on top of 2.3.7.
- `npm run build` and `npm run lint:check` pass.
- No tests added: the repository has no coverage around this event path, and reproducing it requires a live WhatsApp session with a group.
