### PR TITLE
fix(baileys): clear stale credentials when a 401 closes the initial connection

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -322,6 +322,18 @@ export class BaileysStartupService extends ChannelStartupService {
     // is delayed.
     this.stateConnection = { state: 'close', statusReason: 401 };
 
+    await this.clearStoredCredentials();
+  }
+
+  /**
+   * Wipe the stored auth credentials and mark the instance as closed.
+   *
+   * Extracted from logoutInstance() so the loggedOut path in connectionUpdate()
+   * can reuse it. Leaving half-valid credentials behind is what makes an
+   * instance impossible to pair again: Baileys sees the stored identity and
+   * tries to re-authenticate instead of requesting a pairing QR code.
+   */
+  private async clearStoredCredentials() {
     const db = this.configService.get<Database>('DATABASE');
     const cache = this.configService.get<CacheConf>('CACHE');
     const provider = this.configService.get<ProviderSession>('PROVIDER');
@@ -509,6 +521,21 @@ export class BaileysStartupService extends ChannelStartupService {
       const isInitialConnection = !this.instance.wuid && (this.instance.qrcode?.count ?? 0) === 0;
 
       if (isInitialConnection) {
+        // A loggedOut here means the credentials we had stored were rejected
+        // before any QR code could be issued. Returning without clearing them
+        // makes the instance permanently unpairable: on every later attempt
+        // Baileys finds the stored identity (`me` / `account`), tries to
+        // re-authenticate with it instead of asking for a pairing code, gets
+        // another 401, and comes back here. The instance loops forever with
+        // `hasQr: false` and /instance/connect keeps returning an empty code,
+        // so the QR dialog spins and the phone reports a network problem.
+        if (statusCode === DisconnectReason.loggedOut) {
+          this.logger.warn(
+            'Stored credentials were rejected (401) before a QR code was issued; clearing them so the next attempt can pair',
+          );
+          await this.clearStoredCredentials();
+        }
+
         this.logger.info('Initial connection closed, waiting for QR code generation...');
         return;
       }


### PR DESCRIPTION
## Problem

An instance that loses its WhatsApp session becomes **permanently unpairable**. No amount of scanning fixes it, and the failure is reported to the user as a phone/network problem, which is why it took us a long time to trace.

When the connection closes with `loggedOut` before any QR code has been issued, `connectionUpdate()` takes this early return and the stored credentials are never touched:

```ts
const isInitialConnection = !this.instance.wuid && (this.instance.qrcode?.count ?? 0) === 0;

if (isInitialConnection) {
  this.logger.info('Initial connection closed, waiting for QR code generation...');
  return;   // <- credentials left in place
}
```

Those credentials are in a **half-valid state**: the session is gone so `registered` is `false`, but the identity survives. Here is the actual comparison from our server, between a stuck instance and a healthy one created seconds earlier:

| | stuck instance | freshly created instance |
|---|---|---|
| `registered` | `false` | `false` |
| `me.id` | **`15108804692:5@s.whatsapp.net`** | *(none)* |
| `account` | **present** | *(none)* |
| size of `creds` | 1943 bytes | 1250 bytes |
| `GET /instance/connect` | `{"count":0}` | valid QR code |

Baileys then does the reasonable thing with the information it has: it tries to **re-authenticate as that identity** instead of requesting a pairing code. WhatsApp answers `401` because the session no longer exists, the connection closes, and we are back at the same early return.

The result is a loop roughly every ten seconds that never emits a code:

```
17:50:56  connecting, hasQr: false
17:50:57  close, statusCode: 401
17:50:57  "Initial connection closed, waiting for QR code generation..."
17:51:06  connecting, hasQr: false
17:51:10  close, statusCode: 401
17:51:10  "Initial connection closed, waiting for QR code generation..."
```

Downstream, `GET /instance/connect` keeps returning an empty `qrCode` object, so the Manager's QR dialog spins forever, and anyone scanning an older code gets *"Could not log in. Check your phone's internet connection and scan the QR code again"* — pointing the user at their phone rather than at the server.

## Why the existing cleanup does not catch this

`logoutInstance()` already wipes credentials properly, and `monitor.service.ts` calls `cleaningUp()` on the `logout.instance` event. Neither runs here, because the early return happens **before** the code that emits that event.

## Fix

Clear the credentials on that path, so the next attempt starts clean and can pair.

The cleanup logic already existed inside `logoutInstance()`; this extracts it into `clearStoredCredentials()` and reuses it, so both paths stay in sync rather than growing a second copy. Behaviour is unchanged for every status code other than `loggedOut`.

## Why this matters beyond one instance

Recovering from this state currently requires **stopping the container** and deleting the `Session` row by hand — an instance that is still running rewrites the credentials from memory the moment they are deleted, which makes the obvious fix look like it does not work.

The other workaround is deleting and recreating the instance, which is what most people end up doing. That changes the instance id and token, and breaks every n8n flow, Chatwoot inbox and third-party integration pointing at it. For anyone running instances for clients, that is an expensive way out of a state the server can clear by itself.

## Testing

- `tsc --noEmit`: clean across the project (with the Prisma client generated).
- `eslint`: clean on the changed file.
- `npm run build`: succeeds.
- The commit passed the repo's own husky / lint-staged hooks.

Diagnosed on a production deployment running `2.4.0-rc2`. Manually clearing the credentials exactly as this patch does made the affected instance pair on the first scan, after an afternoon of failed attempts. A second instance on the same server still shows the same signature (`connectionStatus: close` with credentials present), which is what the table above compares.

## Summary by Sourcery

Ensure WhatsApp Baileys instances clear rejected credentials on initial 401 closures so they can pair again instead of looping without QR codes.

Bug Fixes:
- Clear stored auth credentials when an initial connection closes with a loggedOut/401 status before QR generation, preventing instances from becoming permanently unpairable.
- Extract shared credential-wiping logic into a reusable helper so both logout and loggedOut connection paths consistently remove stale Baileys credentials.