### PR TITLE
fix: reuse cached group metadata before sends

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3531,7 +3531,9 @@ export class BaileysStartupService extends ChannelStartupService {
     // GROUPS
     const groups = await Promise.all(
       jids.groups.map(async ({ jid, number }) => {
-        const group = await this.findGroup({ groupJid: jid }, 'inner');
+        // Reuse the same metadata cache used by the send path. A fresh
+        // groupMetadata request here added a redundant WhatsApp round-trip.
+        const group = await this.getGroupMetadataCache(jid);
 
         if (!group) {
           return new OnWhatsAppDto(jid, false, number);


### PR DESCRIPTION
## Summary\n- reuse the existing group metadata cache during WhatsApp group resolution\n- remove the redundant groupMetadata round-trip before group sends\n- preserve existing cache-miss validation and cache population behavior\n\n## Validation\n- npm run db:generate\n- npm run build\n- npm run lint:check -- --no-fix\n- targeted group-cache guard and git diff --check

## Summary by Sourcery

Bug Fixes:
- Ensure WhatsApp group resolution uses the same metadata cache as the send path, preventing unnecessary network calls while preserving cache-miss validation behavior.