### PR TITLE
fix(baileys): always emit MESSAGES_UPSERT for media even when S3 upload is skipped or fails

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2777,48 +2777,51 @@ export class BaileysStartupService extends ChannelStartupService {
 
         if (isMedia && this.configService.get<S3>('S3').ENABLE) {
           try {
+            // Skip only the S3 upload here — NOT the whole method. The previous `return`
+            // exited sendMessageWithTyping before sendDataWebhook(Events.SEND_MESSAGE) and
+            // `return messageRaw` below, making POST /message/sendMedia respond empty.
+            // Webhook delivery and the API response must not depend on the storage step.
             if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
-              throw new Error('Video upload is disabled.');
-            }
-
-            const message: any = messageRaw;
-
-            // Verificação adicional para garantir que há conteúdo de mídia real
-            const hasRealMedia = this.hasValidMediaContent(message);
-
-            if (!hasRealMedia) {
-              this.logger.warn('Message detected as media but contains no valid media content');
+              this.logger.warn('Video upload is disabled. Skipping video upload.');
             } else {
-              const media = await this.getBase64FromMediaMessage({ message }, true);
+              const message: any = messageRaw;
 
-              if (!media) {
-                this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
-                return;
+              // Verificação adicional para garantir que há conteúdo de mídia real
+              const hasRealMedia = this.hasValidMediaContent(message);
+
+              if (!hasRealMedia) {
+                this.logger.warn('Message detected as media but contains no valid media content');
+              } else {
+                const media = await this.getBase64FromMediaMessage({ message }, true);
+
+                if (!media) {
+                  this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
+                } else {
+                  const { buffer, mediaType, fileName, size } = media;
+
+                  const mimetype = mimeTypes.lookup(fileName).toString();
+
+                  const fullName = join(
+                    `${this.instance.id}`,
+                    messageRaw.key.remoteJid,
+                    `${messageRaw.key.id}`,
+                    mediaType,
+                    fileName,
+                  );
+
+                  await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
+
+                  await this.prismaRepository.media.create({
+                    data: { messageId: msg.id, instanceId: this.instanceId, type: mediaType, fileName: fullName, mimetype },
+                  });
+
+                  const mediaUrl = await s3Service.getObjectUrl(fullName);
+
+                  messageRaw.message.mediaUrl = mediaUrl;
+
+                  await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
+                }
               }
-
-              const { buffer, mediaType, fileName, size } = media;
-
-              const mimetype = mimeTypes.lookup(fileName).toString();
-
-              const fullName = join(
-                `${this.instance.id}`,
-                messageRaw.key.remoteJid,
-                `${messageRaw.key.id}`,
-                mediaType,
-                fileName,
-              );
-
-              await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
-
-              await this.prismaRepository.media.create({
-                data: { messageId: msg.id, instanceId: this.instanceId, type: mediaType, fileName: fullName, mimetype },
-              });
-
-              const mediaUrl = await s3Service.getObjectUrl(fullName);
-
-              messageRaw.message.mediaUrl = mediaUrl;
-
-              await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
             }
           } catch (error) {
             this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -2812,7 +2812,13 @@ export class BaileysStartupService extends ChannelStartupService {
                   await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
 
                   await this.prismaRepository.media.create({
-                    data: { messageId: msg.id, instanceId: this.instanceId, type: mediaType, fileName: fullName, mimetype },
+                    data: {
+                      messageId: msg.id,
+                      instanceId: this.instanceId,
+                      type: mediaType,
+                      fileName: fullName,
+                      mimetype,
+                    },
                   });
 
                   const mediaUrl = await s3Service.getObjectUrl(fullName);

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1576,52 +1576,59 @@ export class BaileysStartupService extends ChannelStartupService {
             if (isMedia) {
               if (this.configService.get<S3>('S3').ENABLE) {
                 try {
+                  // Skip only the S3 upload here — NOT the whole handler. The
+                  // previous `return` statements exited messages.upsert before
+                  // sendDataWebhook(Events.MESSAGES_UPSERT) below, silently dropping
+                  // every media message whose S3 upload was skipped or failed —
+                  // notably `fromMe` media sent from another device, where
+                  // getBase64FromMediaMessage cannot fetch the file (its mediaKey
+                  // belongs to that device). Webhook delivery must not depend on the
+                  // outcome of the storage step.
                   if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
                     this.logger.warn('Video upload is disabled. Skipping video upload.');
-                    // Skip video upload by returning early from this block
-                    return;
-                  }
-
-                  const message: any = received;
-
-                  // Verificação adicional para garantir que há conteúdo de mídia real
-                  const hasRealMedia = this.hasValidMediaContent(message);
-
-                  if (!hasRealMedia) {
-                    this.logger.warn('Message detected as media but contains no valid media content');
                   } else {
-                    const media = await this.getBase64FromMediaMessage({ message }, true);
+                    const message: any = received;
 
-                    if (!media) {
-                      this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
-                      return;
+                    // Verificação adicional para garantir que há conteúdo de mídia real
+                    const hasRealMedia = this.hasValidMediaContent(message);
+
+                    if (!hasRealMedia) {
+                      this.logger.warn('Message detected as media but contains no valid media content');
+                    } else {
+                      const media = await this.getBase64FromMediaMessage({ message }, true);
+
+                      if (!media) {
+                        this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
+                      } else {
+                        const { buffer, mediaType, fileName, size } = media;
+                        const mimetype = mimeTypes.lookup(fileName).toString();
+                        const fullName = join(
+                          `${this.instance.id}`,
+                          received.key.remoteJid,
+                          mediaType,
+                          `${Date.now()}_${fileName}`,
+                        );
+                        await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, {
+                          'Content-Type': mimetype,
+                        });
+
+                        await this.prismaRepository.media.create({
+                          data: {
+                            messageId: msg.id,
+                            instanceId: this.instanceId,
+                            type: mediaType,
+                            fileName: fullName,
+                            mimetype,
+                          },
+                        });
+
+                        const mediaUrl = await s3Service.getObjectUrl(fullName);
+
+                        (messageRaw.message as any).mediaUrl = mediaUrl;
+
+                        await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
+                      }
                     }
-
-                    const { buffer, mediaType, fileName, size } = media;
-                    const mimetype = mimeTypes.lookup(fileName).toString();
-                    const fullName = join(
-                      `${this.instance.id}`,
-                      received.key.remoteJid,
-                      mediaType,
-                      `${Date.now()}_${fileName}`,
-                    );
-                    await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
-
-                    await this.prismaRepository.media.create({
-                      data: {
-                        messageId: msg.id,
-                        instanceId: this.instanceId,
-                        type: mediaType,
-                        fileName: fullName,
-                        mimetype,
-                      },
-                    });
-
-                    const mediaUrl = await s3Service.getObjectUrl(fullName);
-
-                    (messageRaw.message as any).mediaUrl = mediaUrl;
-
-                    await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
                   }
                 } catch (error) {
                   this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);


### PR DESCRIPTION
## Problem

On the Baileys channel, **media sent from the phone linked to the instance** (`fromMe`, `source = android`/`ios`) — audio, image, document, video — does **not** emit the `MESSAGES_UPSERT` webhook when `S3_ENABLED=true`. The message is persisted and `MESSAGES_UPDATE` (status) is emitted, but the event carrying the actual content never reaches the webhook consumer. Text from the same phone works; media sent through the API works. For any consumer (CRM, chatbot, archiver) this is **silent, permanent loss** — no error, no retry.

## Root cause — structural

`src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`. The S3 upload block uses `return` to skip the upload, but the block sits **before** `sendDataWebhook(Events.MESSAGES_UPSERT, ...)`, so skipping the upload drops the webhook with it. **Webhook delivery must never depend on the outcome of the S3 upload step** — that is the defect.

Concretely reachable on current `develop`: the video-skip branch `if (isVideo && !S3.SAVE_VIDEO) return`. `S3.SAVE_VIDEO` defaults to **false** (`env.config.ts`: `process.env?.S3_SAVE_VIDEO === 'true'`, not set in `.env.example`), so it fires on every video in any S3-enabled install that didn't opt in — and the `return` is inside `for (const received of messages)`, so it aborts the rest of the batch, not just the video.

> Note on the exact path for the broader loss: the affected environment ran with logs suppressed (`LOG_LEVEL=info`), so the precise branch hit for **non-video** media was not instrumented and is not asserted here. The fix does not depend on it — it removes the storage-vs-delivery coupling regardless of which skip path fires.

## Fix

Restructure the S3 block so it skips **only the upload**, never the handler — no `return`/`continue` inside the block; the webhook is **always** emitted. No `throw` for control flow; behavior unchanged when the upload succeeds. **Two sites in this file share the pattern and are both fixed:**

- `messages.upsert` (receive path) — dropped `sendDataWebhook(Events.MESSAGES_UPSERT)`. This is the reported case.
- `sendMessageWithTyping` (API-send path) — the same `if (!media) return` skipped `sendDataWebhook(Events.SEND_MESSAGE)` **and** `return messageRaw`, so `POST /message/sendMedia` responded empty. Same restructure.

## Impact (measured on an affected production deployment)

`fromMe` media delivery to the consumer went from **~7% to 100% (250/250 over 27 h)**, with no per-hour exceptions. A restart-vs-patch confound was ruled out: across three restarts within 11 minutes (the patch present only in the last), delivery was **0/5** on the restarts without the patch and **15/15** on the restart with it. Files remained intact in storage throughout.

## Behavior note

With `S3_SAVE_VIDEO=false` and `WEBHOOK_BASE64=true`, videos that previously vanished now flow through and the base64 block embeds the full video in the webhook payload. This is the previously-dropped media now being delivered — not a regression — but installs that disabled video upload to save bandwidth should be aware. Gate the base64 block by the same `SAVE_VIDEO` flag if that's undesirable.

## Out of scope (called out on purpose)

- `fromMe` media rarely uploads to S3 at all (never gets `mediaUrl`) — **pre-existing**, not introduced here; separate issue.
- The same class of bug exists on the Meta channel (`meta/whatsapp.business.service.ts`) — **separate PR**, not mixed into this one.

## Testing

The repo has no test suite today (`npm test` points at a non-existent `./test/all.test.ts`; the quality CI runs `eslint src` + `tsc --noEmit` + `tsup` only, which pass). Regression cases to lock in when a harness exists:

- `messages.upsert`: with `S3.ENABLE=true` and `S3.SAVE_VIDEO=false`, a `videoMessage` anywhere in a batch must NOT stop `sendDataWebhook(MESSAGES_UPSERT)` from firing for the other messages in that batch.
- `sendMessageWithTyping`: same config, `POST /message/sendMedia` for a video must still return the message object and emit `SEND_MESSAGE` (not respond empty).
