### PR TITLE
fix(baileys): resolve Brazilian 9th digit lost in LID/PN mapping (#2687)

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -4114,7 +4114,18 @@ export class BaileysStartupService extends ChannelStartupService {
           numberVerified = verify.find((v) => v.jid === user.jid);
         }
 
-        const numberJid = numberVerified?.jid || user.jid;
+        let numberJid = numberVerified?.jid || user.jid;
+        if (
+          user.number.startsWith('55') &&
+          user.number.length === 13 &&
+          user.number[4] === '9' &&
+          numberJid.includes('@s.whatsapp.net')
+        ) {
+          const jidNum = numberJid.split('@')[0];
+          if (jidNum.length === 12) {
+            numberJid = `${user.number}@s.whatsapp.net`;
+          }
+        }
 
         return new OnWhatsAppDto(
           numberJid,

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -13,7 +13,7 @@ import { Auth, Chatwoot, ConfigService, Database, HttpServer, Proxy } from '@con
 import { Logger } from '@config/logger.config';
 import { NotFoundException } from '@exceptions';
 import { Contact, Message, Prisma } from '@prisma/client';
-import { createJid } from '@utils/createJid';
+import { createJid, formatBRNumber } from '@utils/createJid';
 import { WASocket } from 'baileys';
 import { isArray } from 'class-validator';
 import EventEmitter2 from 'eventemitter2';
@@ -478,27 +478,8 @@ export class ChannelStartupService {
     return jid;
   }
 
-  // Check if the number is br
   public formatBRNumber(jid: string): string {
-    if (!jid.startsWith('55')) {
-      return jid;
-    }
-
-    // 13-digit Brazilian mobile number (55 + DDD + 9 + 8 digits)
-    if (jid.length === 13) {
-      return jid;
-    }
-
-    // 12-digit Brazilian number (55 + DDD + 8 digits)
-    if (jid.length === 12) {
-      const firstDigit = Number.parseInt(jid[4]);
-      // If local number starts with 6, 7, 8, or 9, it's a mobile number missing the 9th digit '9'
-      if (firstDigit >= 6) {
-        return `${jid.slice(0, 4)}9${jid.slice(4)}`;
-      }
-    }
-
-    return jid;
+    return formatBRNumber(jid);
   }
 
   public async fetchContacts(query: Query<Contact>) {

--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -479,22 +479,26 @@ export class ChannelStartupService {
   }
 
   // Check if the number is br
-  public formatBRNumber(jid: string) {
-    const regexp = new RegExp(/^(\d{2})(\d{2})\d{1}(\d{8})$/);
-    if (regexp.test(jid)) {
-      const match = regexp.exec(jid);
-      if (match && match[1] === '55') {
-        const joker = Number.parseInt(match[3][0]);
-        const ddd = Number.parseInt(match[2]);
-        if (joker < 7 || ddd < 31) {
-          return match[0];
-        }
-        return match[1] + match[2] + match[3];
-      }
-      return jid;
-    } else {
+  public formatBRNumber(jid: string): string {
+    if (!jid.startsWith('55')) {
       return jid;
     }
+
+    // 13-digit Brazilian mobile number (55 + DDD + 9 + 8 digits)
+    if (jid.length === 13) {
+      return jid;
+    }
+
+    // 12-digit Brazilian number (55 + DDD + 8 digits)
+    if (jid.length === 12) {
+      const firstDigit = Number.parseInt(jid[4]);
+      // If local number starts with 6, 7, 8, or 9, it's a mobile number missing the 9th digit '9'
+      if (firstDigit >= 6) {
+        return `${jid.slice(0, 4)}9${jid.slice(4)}`;
+      }
+    }
+
+    return jid;
   }
 
   public async fetchContacts(query: Query<Contact>) {

--- a/src/utils/createJid.ts
+++ b/src/utils/createJid.ts
@@ -14,22 +14,26 @@ function formatMXOrARNumber(jid: string): string {
 }
 
 // Check if the number is br
-function formatBRNumber(jid: string) {
-  const regexp = new RegExp(/^(\d{2})(\d{2})\d{1}(\d{8})$/);
-  if (regexp.test(jid)) {
-    const match = regexp.exec(jid);
-    if (match && match[1] === '55') {
-      const joker = Number.parseInt(match[3][0]);
-      const ddd = Number.parseInt(match[2]);
-      if (joker < 7 || ddd < 31) {
-        return match[0];
-      }
-      return match[1] + match[2] + match[3];
-    }
-    return jid;
-  } else {
+function formatBRNumber(jid: string): string {
+  if (!jid.startsWith('55')) {
     return jid;
   }
+
+  // 13-digit Brazilian mobile number (55 + DDD + 9 + 8 digits)
+  if (jid.length === 13) {
+    return jid;
+  }
+
+  // 12-digit Brazilian number (55 + DDD + 8 digits)
+  if (jid.length === 12) {
+    const firstDigit = Number.parseInt(jid[4]);
+    // If local number starts with 6, 7, 8, or 9, it's a mobile number missing the 9th digit '9'
+    if (firstDigit >= 6) {
+      return `${jid.slice(0, 4)}9${jid.slice(4)}`;
+    }
+  }
+
+  return jid;
 }
 
 export function createJid(number: string): string {

--- a/src/utils/createJid.ts
+++ b/src/utils/createJid.ts
@@ -13,23 +13,32 @@ function formatMXOrARNumber(jid: string): string {
   return jid;
 }
 
-// Check if the number is br
-function formatBRNumber(jid: string): string {
-  if (!jid.startsWith('55')) {
+const BRAZIL_COUNTRY_CODE = '55';
+const BRAZIL_PHONE_WITH_NINTH_DIGIT_LENGTH = 13;
+const BRAZIL_PHONE_WITHOUT_NINTH_DIGIT_LENGTH = 12;
+const BRAZIL_MOBILE_NINTH_DIGIT = '9';
+const COUNTRY_AND_AREA_CODE_LENGTH = 4;
+const FIRST_SUBSCRIBER_DIGIT_INDEX = 4;
+const MINIMUM_MOBILE_FIRST_DIGIT = 6;
+
+export function formatBRNumber(jid: string): string {
+  if (!jid.startsWith(BRAZIL_COUNTRY_CODE)) {
     return jid;
   }
 
-  // 13-digit Brazilian mobile number (55 + DDD + 9 + 8 digits)
-  if (jid.length === 13) {
+  if (jid.length === BRAZIL_PHONE_WITH_NINTH_DIGIT_LENGTH) {
     return jid;
   }
 
-  // 12-digit Brazilian number (55 + DDD + 8 digits)
-  if (jid.length === 12) {
-    const firstDigit = Number.parseInt(jid[4]);
-    // If local number starts with 6, 7, 8, or 9, it's a mobile number missing the 9th digit '9'
-    if (firstDigit >= 6) {
-      return `${jid.slice(0, 4)}9${jid.slice(4)}`;
+  if (jid.length === BRAZIL_PHONE_WITHOUT_NINTH_DIGIT_LENGTH) {
+    const firstSubscriberDigit = Number.parseInt(jid[FIRST_SUBSCRIBER_DIGIT_INDEX]);
+    const isMobileMissingNinthDigit = firstSubscriberDigit >= MINIMUM_MOBILE_FIRST_DIGIT;
+
+    if (isMobileMissingNinthDigit) {
+      const countryAndAreaCode = jid.slice(0, COUNTRY_AND_AREA_CODE_LENGTH);
+      const subscriberNumber = jid.slice(COUNTRY_AND_AREA_CODE_LENGTH);
+
+      return `${countryAndAreaCode}${BRAZIL_MOBILE_NINTH_DIGIT}${subscriberNumber}`;
     }
   }
 

--- a/src/utils/onWhatsappCache.ts
+++ b/src/utils/onWhatsappCache.ts
@@ -22,9 +22,19 @@ function getAvailableNumbers(remoteJid: string) {
 
   // Brazilian numbers
   if (remoteJid.startsWith('55')) {
-    const numberWithDigit =
-      number.slice(4, 5) === '9' && number.length === 13 ? number : `${number.slice(0, 4)}9${number.slice(4)}`;
-    const numberWithoutDigit = number.length === 12 ? number : number.slice(0, 4) + number.slice(5);
+    let numberWithDigit = number;
+    let numberWithoutDigit = number;
+
+    if (number.length === 13 && number.slice(4, 5) === '9') {
+      numberWithDigit = number;
+      numberWithoutDigit = `${number.slice(0, 4)}${number.slice(5)}`;
+    } else if (number.length === 12) {
+      const firstDigit = Number.parseInt(number.slice(4, 5));
+      if (firstDigit >= 6) {
+        numberWithDigit = `${number.slice(0, 4)}9${number.slice(4)}`;
+        numberWithoutDigit = number;
+      }
+    }
 
     numbersAvailable.push(numberWithDigit);
     numbersAvailable.push(numberWithoutDigit);
@@ -129,8 +139,23 @@ export async function saveOnWhatsappCache(data: ISaveOnWhatsappCacheParams[]) {
       const newJidOptionsString = sortedJidOptions.join(',');
       const newLid = item.lid === 'lid' || item.remoteJid?.includes('@lid') ? 'lid' : null;
 
+      let targetRemoteJid = remoteJid;
+      if (existingRecord?.remoteJid) {
+        const existingNum = existingRecord.remoteJid.split('@')[0];
+        const newNum = remoteJid.split('@')[0];
+        if (
+          existingNum.startsWith('55') &&
+          existingNum.length === 13 &&
+          existingNum[4] === '9' &&
+          newNum.startsWith('55') &&
+          newNum.length === 12
+        ) {
+          targetRemoteJid = existingRecord.remoteJid;
+        }
+      }
+
       const dataPayload = {
-        remoteJid: remoteJid,
+        remoteJid: targetRemoteJid,
         jidOptions: newJidOptionsString,
         lid: newLid,
       };

--- a/src/utils/onWhatsappCache.ts
+++ b/src/utils/onWhatsappCache.ts
@@ -37,7 +37,9 @@ function getAvailableNumbers(remoteJid: string) {
     }
 
     numbersAvailable.push(numberWithDigit);
-    numbersAvailable.push(numberWithoutDigit);
+    if (numberWithoutDigit !== numberWithDigit) {
+      numbersAvailable.push(numberWithoutDigit);
+    }
   }
 
   // Mexican/Argentina numbers
@@ -58,7 +60,9 @@ function getAvailableNumbers(remoteJid: string) {
     const numberWithoutDigit = number.length === 12 ? number : number.slice(0, 2) + number.slice(3);
 
     numbersAvailable.push(numberWithDigit);
-    numbersAvailable.push(numberWithoutDigit);
+    if (numberWithoutDigit !== numberWithDigit) {
+      numbersAvailable.push(numberWithoutDigit);
+    }
   }
 
   // Other countries


### PR DESCRIPTION
## 📋 Description
Fixed Brazilian 9th digit handling and LID/PN mapping resolution in Baileys integration:

1. **Fixed `formatBRNumber` stripping the 9th digit**:
   - Resolved legacy regex behavior in `src/utils/createJid.ts` and `src/api/services/channel.service.ts` that stripped the 9th digit ('9') from Brazilian mobile numbers with area codes (DDD) ≥ 31 and subscriber numbers starting with ≥ 7 (e.g. converting `5547989211984` into invalid `554789211984`).
   - Updated `formatBRNumber` to preserve valid 13-digit Brazilian mobile numbers (`55` + DDD + 9 + 8 digits) across all area codes (11-99) and add '9' only when formatting legacy 12-digit mobile numbers.

2. **Cache and JID Resolution (`onWhatsappCache.ts` & `whatsapp.baileys.service.ts`)**:
   - Refined `getAvailableNumbers` and `saveOnWhatsappCache` to prevent existing 13-digit BR JIDs from being downgraded to 12-digit JIDs when updating cache records.
   - Updated `whatsappNumber` resolution in `whatsapp.baileys.service.ts` to prioritize 13-digit BR mobile JIDs over 12-digit legacy JIDs returned by Baileys `onWhatsApp` checks, ensuring outbound messages target valid recipient JIDs and receive `SERVER_ACK` / `DELIVERY_ACK` instead of remaining `PENDING`.

## 🔗 Related Issue
Closes #2687

## 🧪 Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing
- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Tested with different connection types (if applicable)

## 📸 Screenshots (if applicable)
<!-- N/A -->

## ✅ Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## 📝 Additional Notes
- Tested in Docker development environment (`evolution-api:local`).
- To clean up existing corrupted cache entries in production databases without deleting WhatsApp instances, run:
  ```sql
  DELETE FROM "IsOnWhatsapp" WHERE "remoteJid" LIKE '55%' AND LENGTH(SPLIT_PART("remoteJid", '@', 1)) = 12;

## Summary by Sourcery

Fix Brazilian WhatsApp number handling to preserve valid 13-digit mobile JIDs and prefer them over legacy 12-digit mappings in Baileys integration.

Bug Fixes:
- Ensure Brazilian 13-digit mobile numbers retain the 9th digit during BR formatting instead of being incorrectly converted to 12-digit numbers.
- Prevent cache updates from downgrading existing 13-digit Brazilian JIDs to 12-digit legacy JIDs in the onWhatsApp cache.
- Adjust Baileys WhatsApp number resolution to favor 13-digit Brazilian mobile JIDs over 12-digit JIDs returned by onWhatsApp checks.