### PR TITLE
fix(meta): guard non-string mimetype before image check (fixes #2678)

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -1125,7 +1125,10 @@ export class BusinessStartupService extends ChannelStartupService {
           return await this.post(content, 'messages');
         }
         if (message['media']) {
-          const isImage = message['mimetype']?.startsWith('image/');
+          // `mimeTypes.lookup()` returns `false`, not `undefined`, when it cannot resolve the
+          // type, for example a Chatwoot ActiveStorage URL with no file extension. Optional
+          // chaining only guards `null` and `undefined`, so `false.startsWith` would throw.
+          const isImage = typeof message['mimetype'] === 'string' && message['mimetype'].startsWith('image/');
 
           content = {
             messaging_product: 'whatsapp',

--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -1125,9 +1125,8 @@ export class BusinessStartupService extends ChannelStartupService {
           return await this.post(content, 'messages');
         }
         if (message['media']) {
-          // `mimeTypes.lookup()` returns `false`, not `undefined`, when it cannot resolve the
-          // type, for example a Chatwoot ActiveStorage URL with no file extension. Optional
-          // chaining only guards `null` and `undefined`, so `false.startsWith` would throw.
+          // `mimeTypes.lookup()` returns `false`, not `undefined`, when the URL has no file
+          // extension, and optional chaining only guards `null` and `undefined`.
           const isImage = typeof message['mimetype'] === 'string' && message['mimetype'].startsWith('image/');
 
           content = {


### PR DESCRIPTION
## 📋 Description

`mimeTypes.lookup()` returns `false`, not `undefined`, when it cannot resolve a type. Chatwoot serves attachments through Rails ActiveStorage URLs that carry no file extension, so for every Chatwoot audio the lookup in `processAudio()` returns `false` and `prepareMedia.mimetype` is set to `false`.

Line 1128 of `whatsapp.business.service.ts` then runs:

```ts
const isImage = message['mimetype']?.startsWith('image/');
```

Optional chaining only short-circuits on `null` and `undefined`. `false` is neither, so the call reaches `false.startsWith` and throws `TypeError: mimetype?.startsWith is not a function` before the request ever leaves for Meta.

This changes the check to an explicit type guard:

```ts
const isImage = typeof message['mimetype'] === 'string' && message['mimetype'].startsWith('image/');
```

## 🔗 Related Issue

Closes #2678

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] 🧹 Code cleanup
- [ ] 🔒 Security fix

## 🧪 Testing

- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [ ] Tested with different connection types (if applicable)

I reproduced the failure without a Chatwoot instance, by running the repository's own `mime-types` dependency against the exact expression from line 1128:

```
STEP 1 - what mimeTypes.lookup() returns
   false         Chatwoot (ActiveStorage, no extension)
   false         Chatwoot (bare blob)
   "audio/ogg"   normal URL with extension

STEP 2 - the object processAudio() returns
   {"mediaType":"audio","type":"link","mimetype":false}
   typeof message.mimetype: boolean

STEP 3 - line 1128 on develop, before the fix
   THROWS -> TypeError: message.mimetype?.startsWith is not a function
```

With the guard in place all four cases behave, and the existing behaviour for real MIME strings is unchanged:

| `mimetype` | `isImage` |
|---|---|
| `false` (Chatwoot) | `false` |
| `undefined` | `false` |
| `"audio/ogg"` | `false` |
| `"image/png"` | `true` |

Gates run locally on this branch (based on the current `develop` tip):

- `npm run lint:check` — clean
- `npm run build` (`tsc --noEmit` + `tsup`) — passes

I did not run `npm test`: the script points at `./test/all.test.ts`, which does not exist on `develop`.

## 📸 Screenshots (if applicable)

N/A — backend-only change.

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [ ] Any dependent changes have been merged and published

## 📝 Additional Notes

**Why only audio is affected.** In `chatwoot.service.ts`, `sendAttachment()` downloads the file specifically to read its `Content-Type` when the extension-based lookup fails:

```ts
let mimeType = mimeTypes.lookup(parsedMedia?.ext) || '';

if (!mimeType) {
  const response = await axios.get(media, { responseType: 'arraybuffer' });
  mimeType = response.headers['content-type'] as string;
}
```

It then uses that value to route the message, but on the audio branch it passes only the raw URL to `audioWhatsapp()` and the resolved MIME type is dropped. `processAudio()` re-derives it from the same extension-less URL and gets `false`.

**This looks like an oversight rather than intent.** The line above, in `chatwoot.service.ts`, already normalizes the same call with `|| ''`. The `false` return value is understood elsewhere in the codebase, it is just not handled at this consumer. `processAudio()` and `processMedia()` even declare `let mimetype: string | false`, so the type is documented in the signature.

**Why the guard is here and not in the producers.** `startsWith('image/')` has exactly one call site in `src/`, this one. `processMedia()` (lines 1379 and 1383 on `develop`) uses the same `string | false` pattern and feeds the same line, so an image or document sent from an extension-less URL would hit the identical crash. One guard at the point of use covers every producer. Normalizing `false` to `undefined` in `processAudio()` alone would fix audio only.

**No behaviour change on the audio path.** For audio, `isImage` is only read inside a spread that already excludes `audio`, so the payload sent to Meta is byte-for-byte the same. The change removes the exception and nothing else.

Happy to move the normalization into `processAudio()` and `processMedia()` instead if you would prefer the producers to hand back a clean value, and equally happy to be told I have misread something. I am new to this codebase.
