### PR TITLE
fix(chat): normalize @lid JIDs to @s.whatsapp.net and include Contact table entries in fetchChats

### DIFF
--- a/src/api/services/channel.service.ts
+++ b/src/api/services/channel.service.ts
@@ -742,7 +742,7 @@ export class ChannelStartupService {
     const offset = query?.skip ? Prisma.sql`OFFSET ${query.skip}` : Prisma.sql``;
 
     const results = await this.prismaRepository.$queryRaw`
-      WITH rankedMessages AS (
+      WITH msg_chats AS (
         SELECT DISTINCT ON ("Message"."key"->>'remoteJid') 
           "Contact"."id" as "contactId",
           "Message"."key"->>'remoteJid' as "remoteJid",
@@ -755,7 +755,7 @@ export class ChannelStartupService {
             to_timestamp("Message"."messageTimestamp"::double precision), 
             "Contact"."updatedAt"
           ) as "updatedAt",
-          "Chat"."name" as "pushName",
+          "Chat"."name" as "chatName",
           "Chat"."createdAt" as "windowStart",
           "Chat"."createdAt" + INTERVAL '24 hours' as "windowExpires",
           "Chat"."unreadMessages" as "unreadMessages",
@@ -770,7 +770,7 @@ export class ChannelStartupService {
           "Message"."messageType" AS "lastMessageMessageType",
           "Message"."message" AS "lastMessageMessage",
           "Message"."contextInfo" AS "lastMessageContextInfo",
-          "Message"."source" AS "lastMessageSource",
+          "Message"."source"::text AS "lastMessageSource",
           "Message"."messageTimestamp" AS "lastMessageMessageTimestamp",
           "Message"."instanceId" AS "lastMessageInstanceId",
           "Message"."sessionId" AS "lastMessageSessionId",
@@ -782,9 +782,43 @@ export class ChannelStartupService {
         ${remoteJid ? Prisma.sql`AND "Message"."key"->>'remoteJid' = ${remoteJid}` : Prisma.sql``}
         ${timestampFilter}
         ORDER BY "Message"."key"->>'remoteJid', "Message"."messageTimestamp" DESC
+      ),
+      contact_chats AS (
+        SELECT 
+          "Contact"."id" as "contactId",
+          "Contact"."remoteJid" as "remoteJid",
+          "Contact"."pushName" as "pushName",
+          "Contact"."profilePicUrl",
+          "Contact"."updatedAt" as "updatedAt",
+          "Chat"."name" as "chatName",
+          "Chat"."createdAt" as "windowStart",
+          "Chat"."createdAt" + INTERVAL '24 hours' as "windowExpires",
+          COALESCE("Chat"."unreadMessages", 0) as "unreadMessages",
+          CASE WHEN "Chat"."createdAt" + INTERVAL '24 hours' > NOW() THEN true ELSE false END as "windowActive",
+          NULL::text AS "lastMessageId",
+          NULL::jsonb AS "lastMessage_key",
+          NULL::text AS "lastMessagePushName",
+          NULL::text AS "lastMessageParticipant",
+          NULL::text AS "lastMessageMessageType",
+          NULL::jsonb AS "lastMessageMessage",
+          NULL::jsonb AS "lastMessageContextInfo",
+          NULL::text AS "lastMessageSource",
+          NULL::integer AS "lastMessageMessageTimestamp",
+          "Contact"."instanceId" AS "lastMessageInstanceId",
+          NULL::text AS "lastMessageSessionId",
+          NULL::text AS "lastMessageStatus"
+        FROM "Contact"
+        LEFT JOIN "Chat" ON "Chat"."remoteJid" = "Contact"."remoteJid" AND "Chat"."instanceId" = "Contact"."instanceId"
+        WHERE "Contact"."instanceId" = ${this.instanceId}
+        ${remoteJid ? Prisma.sql`AND "Contact"."remoteJid" = ${remoteJid}` : Prisma.sql``}
+      ),
+      combined_chats AS (
+        SELECT * FROM msg_chats
+        UNION ALL
+        SELECT * FROM contact_chats
       )
-      SELECT * FROM rankedMessages 
-      ORDER BY "updatedAt" DESC NULLS LAST
+      SELECT DISTINCT ON ("remoteJid") * FROM combined_chats 
+      ORDER BY "remoteJid", "updatedAt" DESC NULLS LAST
       ${limit}
       ${offset};
     `;
@@ -808,17 +842,22 @@ export class ChannelStartupService {
             }
           : undefined;
 
+        let finalRemoteJid = contact.remoteJid;
+        if (finalRemoteJid && finalRemoteJid.endsWith('@lid')) {
+          finalRemoteJid = finalRemoteJid.replace('@lid', '@s.whatsapp.net');
+        }
+
         return {
           id: contact.contactId || null,
-          remoteJid: contact.remoteJid,
-          pushName: contact.pushName,
+          remoteJid: finalRemoteJid,
+          pushName: contact.pushName || finalRemoteJid?.split('@')[0] || 'Contato',
           profilePicUrl: contact.profilePicUrl,
           updatedAt: contact.updatedAt,
           windowStart: contact.windowStart,
           windowExpires: contact.windowExpires,
           windowActive: contact.windowActive,
           lastMessage: lastMessage ? this.cleanMessageData(lastMessage) : undefined,
-          unreadCount: contact.unreadMessages,
+          unreadCount: contact.unreadMessages || 0,
           isSaved: !!contact.contactId,
         };
       });


### PR DESCRIPTION
## Description

This PR resolves an issue where personal 1-on-1 chats and contacts fail to render in the Evolution Manager UI due to WhatsApp Multi-Device `@lid` (Linked Identity) JIDs and unlinked `"Contact"` table records.

### 🐛 Problem
1. **`@lid` JID Filtering in Frontend:** WhatsApp Multi-Device assigns `@lid` domain JIDs (e.g., `173452640125135@lid`) to incoming messages and chats. However, the Evolution Manager UI filters personal contacts strictly checking if `remoteJid` ends with `@s.whatsapp.net`. As a result, all `@lid` personal chats are hidden from the `Contatos` tab in the UI.
2. **Missing Contact Records:** `fetchChats` previously queried solely from the `"Message"` table. Contacts saved in the `"Contact"` table without message history were excluded from the chat sidebar.
3. **PostgreSQL Type Mismatch:** Combining raw SQL subqueries required explicit PostgreSQL type casting for JSONB and Enum types.

---

## 🛠️ Solution

1. **JID Normalization:** Added JID normalization in `src/api/services/channel.service.ts` (`fetchChats`) to format `@lid` suffixes to `@s.whatsapp.net` in the API output payload, ensuring full compatibility with Evolution Manager UI.
2. **CTE UNION Query:** Refactored `fetchChats` SQL query into Common Table Expressions (`msg_chats` & `contact_chats`) joined by `UNION ALL` to include both active message threads and saved address book contacts.
3. **Explicit Type Casting:** Applied explicit PostgreSQL type casting (`NULL::jsonb`, `NULL::text`, `NULL::integer`) to ensure schema compatibility across PostgreSQL database instances.

---

## 🧪 How Has This Been Tested?

- Verified `POST /chat/findChats/:instanceName` returns all 1-on-1 personal contacts with `@s.whatsapp.net` JIDs.
- Tested on Evolution Manager UI (v2.3.7): all personal contacts, group chats (`@g.us`), push names, profile pictures, and last message previews are displayed and selectable.
- Confirmed backward compatibility with sending text messages and webhook triggers.

## Summary by Sourcery

Ensure personal chats and saved contacts are consistently returned and displayed by normalizing JIDs and expanding chat retrieval beyond message history.

Bug Fixes:
- Normalize WhatsApp @lid personal chat identifiers to standard @s.whatsapp.net JIDs so contacts render correctly in the manager UI.
- Include saved contacts without message history in fetched chats, while preserving message-backed conversations and defaulting missing metadata appropriately.

Enhancements:
- Refactor chat retrieval to combine message conversations and address-book contacts with duplicate chat consolidation and PostgreSQL-compatible type handling.