### PR TITLE
fix: preserve reply metadata when flattening extendedTextMessage

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -5700,12 +5700,22 @@ export class BaileysStartupService extends ChannelStartupService {
       if (!message.pushName) {
         if (messageKey.fromMe) {
           message.pushName = 'Você';
+        } else if (messageKey.participant) {
+          /**
+           * The sender comes from the message key.
+           *
+           * `contextInfo.participant` is the author of the QUOTED message, not
+           * of this one, so it may only stand in when the key carries nothing.
+           * It used to be checked first, which was harmless while contextInfo
+           * never carried a participant — and would mislabel the sender of a
+           * text reply now that the quote is preserved.
+           */
+          message.pushName = messageKey.participant.split('@')[0];
         } else if (message.contextInfo) {
           const contextInfo = message.contextInfo as { participant?: string };
+
           if (contextInfo.participant) {
             message.pushName = contextInfo.participant.split('@')[0];
-          } else if (messageKey.participant) {
-            message.pushName = messageKey.participant.split('@')[0];
           }
         }
       }

--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -5184,6 +5184,21 @@ export class BaileysStartupService extends ChannelStartupService {
     if (messageRaw.message.extendedTextMessage) {
       messageRaw.messageType = 'conversation';
       messageRaw.message.conversation = messageRaw.message.extendedTextMessage.text;
+
+      /**
+       * Keep the reply metadata before dropping the wrapper.
+       *
+       * `stanzaId`, `participant` and `quotedMessage` live inside the
+       * extendedTextMessage's own contextInfo. Deleting the wrapper dropped
+       * them, so every text reply reached webhooks and the database unquoted,
+       * while media replies (never flattened) kept theirs.
+       */
+      const quotedContext = messageRaw.message.extendedTextMessage.contextInfo;
+
+      if (quotedContext) {
+        messageRaw.contextInfo = { ...(messageRaw.contextInfo ?? {}), ...quotedContext };
+      }
+
       delete messageRaw.message.extendedTextMessage;
     }
 


### PR DESCRIPTION
## 📋 Description

`prepareMessage()` flattens `extendedTextMessage` into `conversation` and deletes the wrapper. A text reply carries its quote in `extendedTextMessage.contextInfo` (`stanzaId`, `participant`, `quotedMessage`), so deleting the wrapper drops the reply metadata before it reaches webhooks, the database and every integration.

The data-level `contextInfo` on the payload is built from `messageContextInfo`, which carries `threadId` / `messageSecret` / `limitSharingV2` and never `stanzaId` — so nothing downstream can recover the quote.

Media replies are unaffected: `imageMessage`, `audioMessage`, `stickerMessage` and friends are never flattened, and their own `contextInfo` survives. The result is that the quote is lost based on what the reply **is**, not on what it quotes — replying with audio keeps the quote, replying with text loses it.

This PR keeps the quote before dropping the wrapper. Two notes on the shape of the fix:

1. It puts the reply metadata exactly where the code immediately below already expects it. The `const quotedMessage = messageRaw?.contextInfo?.quotedMessage` block that normalizes the quoted preview is currently unreachable for text messages; this makes existing code work as written instead of introducing a new convention.
2. `messageRaw.message` has already been through `deserializeMessageBuffers()` a few lines above, so no extra deserialization is needed. Existing `messageContextInfo` keys are spread first and therefore preserved — `messageSecret` and message editing are untouched.

## 🔗 Related Issue

Relates to #2078

## 🧪 Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## 🧪 Testing

- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced
- [x] Tested with different connection types (if applicable)

Measured on an instance running `2.4.0-rc2` with real traffic (MySQL, 36,805 stored messages).

**Before the fix:**

| messageType | total | with `stanzaId` |
|---|---|---|
| conversation | 17,170 | **0** |
| imageMessage | 11,298 | 21 |
| audioMessage | 3,577 | 78 |
| documentMessage | 2,163 | 19 |
| stickerMessage | 260 | 12 |

**After the fix:** every connected session reconnected normally with no errors in the logs, and within minutes a real inbound text reply arrived carrying `stanzaId` in `contextInfo`, in both the sender's and the receiver's copy. The consuming CRM stored the reply linked to its quoted message — something that had never happened on this installation.

The change is additive: it only adds keys to `contextInfo` when the incoming message actually carries a quote.

## ✅ Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios

## 📝 Additional Notes

I did not add an automated test: `package.json` points `test` at `./test/all.test.ts`, which is not present in the repository, so there is no suite to extend. Happy to add one if you can point me at where it should live.

I also did not bisect the 2.3.2 → 2.3.3 boundary mentioned in #2078. What is verified here is the behavior of current `develop` and of the `2.4.0-rc2` image; the symptom matches that report, but I cannot confirm it is the same change that caused that regression.

## Summary by Sourcery

Preserve reply context and correctly identify senders for flattened WhatsApp text messages.

Bug Fixes:
- Preserve quoted-message metadata when flattening text replies so webhook, database, and integration consumers can retain reply relationships.
- Use the actual message-key participant when deriving sender names, preventing quoted-message authors from being misidentified as the current sender.