### PR TITLE
fix(meta): use continue instead of return when processing status batches

### DIFF
--- a/src/api/integrations/channel/meta/whatsapp.business.service.ts
+++ b/src/api/integrations/channel/meta/whatsapp.business.service.ts
@@ -857,7 +857,7 @@ export class BusinessStartupService extends ChannelStartupService {
             fromMe: this.isCloudApiStatusFromMe(item, received),
           };
           if (settings?.groups_ignore && key.remoteJid.includes('@g.us')) {
-            return;
+            continue;
           }
           if (key.remoteJid !== 'status@broadcast' && !key?.remoteJid?.match(/(:\d+)/)) {
             const findMessage = await this.prismaRepository.message.findFirst({
@@ -871,7 +871,7 @@ export class BusinessStartupService extends ChannelStartupService {
             });
 
             if (!findMessage) {
-              return;
+              continue;
             }
 
             const findMessageKey: any = findMessage?.key ?? {};
@@ -907,7 +907,7 @@ export class BusinessStartupService extends ChannelStartupService {
                 );
               }
 
-              return;
+              continue;
             }
 
             const message: any = {


### PR DESCRIPTION
## Description

The WhatsApp Cloud API (Meta Business channel) delivers message status updates in batches: a single webhook payload can contain multiple entries in `received.statuses`. In `BusinessStartupService.messageHandle`, the loop `for await (const item of received.statuses)` used `return` in three places where per-item skipping was intended, so a single item hitting one of these paths silently aborted processing of every remaining status in the same batch (while still returning `200` to Meta):

1. **`groups_ignore` guard**: one group (`@g.us`) status dropped all subsequent non-group statuses in the batch.
2. **`!findMessage` guard**: a status for a message not present in the database (e.g. sent outside Evolution, directly via the Graph API, or from the WhatsApp Business app on the phone) dropped the rest of the batch. This is the most impactful case, since Meta commonly batches statuses for several messages into one payload. One "foreign" wamid arriving first meant delivery and read receipts went missing for messages Evolution does own, with nothing in the logs.
3. **End of the `MESSAGES_DELETE` branch**: after correctly handling a delete event, the remaining items in the batch were never processed, so their `MESSAGES_UPDATE` events were not emitted, not persisted to `messageUpdate`, and not forwarded to Chatwoot or per-message webhooks.

This PR replaces those three `return` statements with `continue`, so each guard skips only the current item. In all three sites, `return` was the last statement on its code path within the iteration, so `continue` is behaviorally identical for the current item and only restores processing of the remaining items.

This also matches the pattern already used in the Baileys channel service (`whatsapp.baileys.service.ts`), whose `messages.update` handler uses `continue` for the identical per-item guards, including the same groups-ignore check.

## Related Issue

Closes #2700

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Manual testing completed
- [x] Functionality verified in development environment
- [x] No breaking changes introduced

Verification performed:

- `npm run lint:check`, `npm run db:generate` and `npm run build` all pass locally (same steps as the `check_code_quality` CI workflow).
- Traced the webhook flow: with a Cloud API status payload containing e.g. a group status followed by a regular status, the regular status was previously dropped (no `MESSAGES_UPDATE` event, no `messageUpdate` row, no per-message webhook call); with this change it is processed.
- The repository has no automated test infrastructure for this service, so no unit tests were added.

## Screenshots (if applicable)

N/A, control-flow-only change.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have manually tested my changes thoroughly
- [x] I have verified the changes work with different scenarios
- [x] Any dependent changes have been merged and published

## Additional Notes

There is a related but distinct remaining weakness: an exception thrown inside the loop (for example the per-message `axios.post(findMessage.webhookUrl, message)` at the end of an iteration, or a Prisma error) propagates to the method's outer `try/catch` and also aborts the remaining batch. I intentionally kept this PR limited to the fix proposed in the issue to keep the diff minimal. If maintainers would like, I can submit a follow-up wrapping each iteration in a `try/catch` so one failing item cannot abort the batch.

