### PR TITLE
fix(chatwoot): skip duplicate messages when a device redelivers the same key.id

### DIFF
--- a/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
+++ b/src/api/integrations/chatbot/chatwoot/services/chatwoot.service.ts
@@ -2240,6 +2240,17 @@ export class ChatwootService {
           return;
         }
 
+        if (body.key.id && this.isImportHistoryAvailable()) {
+          const sourceId = 'WAID:' + body.key.id;
+          const messageAlreadySaved = await chatwootImport.getExistingSourceIds([sourceId], getConversation);
+          if (messageAlreadySaved) {
+            if (messageAlreadySaved.size > 0) {
+              this.logger.warn('Message already saved on chatwoot');
+              return;
+            }
+          }
+        }
+
         const messageType = body.key.fromMe ? 'outgoing' : 'incoming';
 
         if (isMedia) {


### PR DESCRIPTION
Fixes #2675

## Root cause

When a sender device redelivers a message with the same key.id (for example an unofficial client stuck in a resend loop), the live event path (messages.upsert / send.message) posts a new Chatwoot message on every arrival. There is no idempotency check on that path: the reporter accumulated 837 copies of a single message in one conversation, while WhatsApp itself shows it once thanks to native key.id dedup.

## Fix

Reuse the exact dedup pattern sendData already applies to media messages: query Chatwoot's messages.source_id via chatwootImport.getExistingSourceIds before posting, gated by isImportHistoryAvailable(), and skip the message when WAID:<key.id> already exists in the target conversation. The check runs once at the top of the messages.upsert / send.message block, right after the conversation is resolved, so a single block covers every live path: plain text (group and direct), reactions, interactive button messages, ads and media.

## Design decisions

- Gated by isImportHistoryAvailable(), matching sendData: the lookup needs the Chatwoot database connection; without it the check is skipped and behavior is unchanged.
- Fail open: getExistingSourceIds catches its own errors, logs them and returns an empty set, so a Chatwoot DB outage never blocks delivery. Losing dedup is acceptable; losing a message is not. This is also why there is no extra try/catch in the caller, unlike the snippet suggested in the issue.
- The check is deliberately not inside createMessage, where the issue's suggested patch placed it. The messages.edit / send.message.update path re-posts an edited-message notice using the original message's WAID source id, so a check inside createMessage would silently drop every edit. Checking once per event also keeps multi-button interactive messages intact (they post several Chatwoot messages sharing one key.id within a single event).

## Verification

The repository has no unit test infrastructure (npm test points to a non-existent test/all.test.ts), so no automated test is included. npm run lint:check and npm run build pass. Behavior per scenario:

- New message: created in Chatwoot normally (lookup misses, flow unchanged).
- Same key.id redelivered to the same conversation: skipped, logs "Message already saved on chatwoot".
- Chatwoot DB connection failing: helper logs "Error on getExistingSourceIds" and returns an empty set, the message is still created (fail open).
- Import database URI unset or left as the placeholder: check skipped entirely, behavior identical to today.
- Edited message: still posted (that path is untouched).

## Known limitations (shared with the existing sendData check)

- getExistingSourceIds filters by the conversation id returned by the Chatwoot API, which is the per-account display_id, while messages.conversation_id in the Chatwoot schema is the conversation primary key. On single-account installs they coincide; on multi-account installs the lookup can miss. This limitation already applies to the media path today and is worth a separate fix in the helper.
- The Chatwoot import Pool is created without connection or statement timeouts, so the lookup inherits pg defaults. Also pre-existing on the media path; a separate hardening PR could add timeouts.

Note: open PR #2614 changes the second argument of getExistingSourceIds from a number to an options object; whichever lands second needs a one-line adjustment in this call.

## Summary by Sourcery

Skip live messages whose WhatsApp key IDs are already recorded in the target Chatwoot conversation.

Bug Fixes:
- Prevent duplicate live Chatwoot messages when WhatsApp redelivers an event with an already-seen message key ID.

Enhancements:
- Apply source-ID deduplication across supported live message types while preserving edited-message delivery and allowing delivery to continue when the lookup is unavailable.