### PR TITLE
fix(baileys): recreate messageSubject when it is stopped, not only closed

### DIFF
--- a/src/api/integrations/channel/whatsapp/baileysMessage.processor.ts
+++ b/src/api/integrations/channel/whatsapp/baileysMessage.processor.ts
@@ -24,8 +24,10 @@ export class BaileysMessageProcessor {
       this.subscription.unsubscribe();
     }
 
-    // Se o Subject foi completado, recriar
-    if (this.messageSubject.closed) {
+    // A completed Subject silently drops every `next()`, but `complete()` only sets
+    // `isStopped` — `closed` stays false (it is set by `unsubscribe()`). Checking `closed`
+    // alone never recreates the Subject, so the instance stays deaf after a logout.
+    if (this.messageSubject.closed || this.messageSubject.isStopped) {
       this.processorLogs.warn('MessageSubject was closed, recreating...');
       this.messageSubject = new Subject<{
         messages: WAMessage[];


### PR DESCRIPTION
## Summary

The reconnection fix from #2186 **never triggers**. `onDestroy()` calls `complete()` on the RxJS Subject, which sets `isStopped` — it does **not** set `closed`. Only `unsubscribe()` sets `closed`.

Since `mount()` guards the recreation with `if (this.messageSubject.closed)`, the condition is always `false` after a logout. The Subject is never recreated, and the instance keeps silently dropping every incoming message — the exact bug #2186 set out to fix. The `MessageSubject was closed, recreating...` warning is never logged, which is why the problem is so hard to spot.

## Evidence

Verified against the project's own rxjs (7.8.2):

```js
const s = new Subject();
console.log(s.closed, s.isStopped);  // false false
s.complete();
console.log(s.closed, s.isStopped);  // false true   <- complete() sets isStopped, not closed

let n = 0;
s.subscribe({ next: () => n++ });    // this is what mount() does
s.next({ x: 1 });
console.log(n);                       // 0  -> the Subject is deaf
```

The guard `if (this.messageSubject.closed)` evaluates to `false` here, so the Subject is never replaced.

## Reproduced in production

Self-hosted 2.3.6 fork, 8 pm2 instances. Same sequence each time — disconnect via `DELETE /instance/logout`, reconnect via `GET /instance/connect`, then send an inbound message:

| run | version | inbound message |
|---|---|---|
| 1 | without the fix | **lost** |
| 2 | with #2186 exactly as merged | **lost** |
| 3 | with this patch | **delivered** |

Run 2 is the important one: the fix was deployed and the message was still dropped, with no warning logged.

With this patch, the log shows the recreation 3 seconds after the logout, and the message is processed normally without restarting the process:

```
01:10:23  WARN [WAMonitoringService]     Instance "…" - LOGOUT
01:10:26  WARN [BaileysMessageProcessor] MessageSubject was closed, recreating...
01:12:08  LOG  [BaileysMessageProcessor] Processing batch of 1 messages
```

Worth noting how quiet the failure is: the instance stays `open`, **outgoing messages keep working**, and nothing is logged — so it reads as "the customer never replied". In our case a scheduled process restart was masking it three times a day.

## Change

```diff
-    // Se o Subject foi completado, recriar
-    if (this.messageSubject.closed) {
+    if (this.messageSubject.closed || this.messageSubject.isStopped) {
```

`closed` is kept in the condition since either state makes the Subject unusable; `isStopped` is the one the logout path actually produces.

Affects `main`, `develop` and 2.4.0-rc, which all still carry the original guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Ensure the WhatsApp message subject is recreated after logout so incoming messages continue to be processed.