### PR TITLE
fix(baileys): never let the S3 upload step drop the message webhook

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -1576,52 +1576,55 @@ export class BaileysStartupService extends ChannelStartupService {
             if (isMedia) {
               if (this.configService.get<S3>('S3').ENABLE) {
                 try {
+                  // Skip only the S3 upload here — NOT the whole handler. The previous `return`
+                  // statements exited messages.upsert before sendDataWebhook(Events.MESSAGES_UPSERT)
+                  // below, silently dropping the message. Webhook delivery must never depend on the
+                  // outcome of the storage step.
                   if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
                     this.logger.warn('Video upload is disabled. Skipping video upload.');
-                    // Skip video upload by returning early from this block
-                    return;
-                  }
-
-                  const message: any = received;
-
-                  // Verificação adicional para garantir que há conteúdo de mídia real
-                  const hasRealMedia = this.hasValidMediaContent(message);
-
-                  if (!hasRealMedia) {
-                    this.logger.warn('Message detected as media but contains no valid media content');
                   } else {
-                    const media = await this.getBase64FromMediaMessage({ message }, true);
+                    const message: any = received;
 
-                    if (!media) {
-                      this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
-                      return;
+                    // Verificação adicional para garantir que há conteúdo de mídia real
+                    const hasRealMedia = this.hasValidMediaContent(message);
+
+                    if (!hasRealMedia) {
+                      this.logger.warn('Message detected as media but contains no valid media content');
+                    } else {
+                      const media = await this.getBase64FromMediaMessage({ message }, true);
+
+                      if (!media) {
+                        this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
+                      } else {
+                        const { buffer, mediaType, fileName, size } = media;
+                        const mimetype = mimeTypes.lookup(fileName).toString();
+                        const fullName = join(
+                          `${this.instance.id}`,
+                          received.key.remoteJid,
+                          mediaType,
+                          `${Date.now()}_${fileName}`,
+                        );
+                        await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, {
+                          'Content-Type': mimetype,
+                        });
+
+                        await this.prismaRepository.media.create({
+                          data: {
+                            messageId: msg.id,
+                            instanceId: this.instanceId,
+                            type: mediaType,
+                            fileName: fullName,
+                            mimetype,
+                          },
+                        });
+
+                        const mediaUrl = await s3Service.getObjectUrl(fullName);
+
+                        (messageRaw.message as any).mediaUrl = mediaUrl;
+
+                        await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
+                      }
                     }
-
-                    const { buffer, mediaType, fileName, size } = media;
-                    const mimetype = mimeTypes.lookup(fileName).toString();
-                    const fullName = join(
-                      `${this.instance.id}`,
-                      received.key.remoteJid,
-                      mediaType,
-                      `${Date.now()}_${fileName}`,
-                    );
-                    await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
-
-                    await this.prismaRepository.media.create({
-                      data: {
-                        messageId: msg.id,
-                        instanceId: this.instanceId,
-                        type: mediaType,
-                        fileName: fullName,
-                        mimetype,
-                      },
-                    });
-
-                    const mediaUrl = await s3Service.getObjectUrl(fullName);
-
-                    (messageRaw.message as any).mediaUrl = mediaUrl;
-
-                    await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
                   }
                 } catch (error) {
                   this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);
@@ -2770,48 +2773,56 @@ export class BaileysStartupService extends ChannelStartupService {
 
         if (isMedia && this.configService.get<S3>('S3').ENABLE) {
           try {
+            // Skip only the S3 upload here — NOT the whole method. The previous `return` exited
+            // sendMessageWithTyping before sendDataWebhook(Events.SEND_MESSAGE) and the
+            // `return messageRaw` below, making POST /message/sendMedia respond empty.
             if (isVideo && !this.configService.get<S3>('S3').SAVE_VIDEO) {
-              throw new Error('Video upload is disabled.');
-            }
-
-            const message: any = messageRaw;
-
-            // Verificação adicional para garantir que há conteúdo de mídia real
-            const hasRealMedia = this.hasValidMediaContent(message);
-
-            if (!hasRealMedia) {
-              this.logger.warn('Message detected as media but contains no valid media content');
+              this.logger.warn('Video upload is disabled. Skipping video upload.');
             } else {
-              const media = await this.getBase64FromMediaMessage({ message }, true);
+              const message: any = messageRaw;
 
-              if (!media) {
-                this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
-                return;
+              // Verificação adicional para garantir que há conteúdo de mídia real
+              const hasRealMedia = this.hasValidMediaContent(message);
+
+              if (!hasRealMedia) {
+                this.logger.warn('Message detected as media but contains no valid media content');
+              } else {
+                const media = await this.getBase64FromMediaMessage({ message }, true);
+
+                if (!media) {
+                  this.logger.verbose('No valid media to upload (messageContextInfo only), skipping MinIO');
+                } else {
+                  const { buffer, mediaType, fileName, size } = media;
+
+                  const mimetype = mimeTypes.lookup(fileName).toString();
+
+                  const fullName = join(
+                    `${this.instance.id}`,
+                    messageRaw.key.remoteJid,
+                    `${messageRaw.key.id}`,
+                    mediaType,
+                    fileName,
+                  );
+
+                  await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
+
+                  await this.prismaRepository.media.create({
+                    data: {
+                      messageId: msg.id,
+                      instanceId: this.instanceId,
+                      type: mediaType,
+                      fileName: fullName,
+                      mimetype,
+                    },
+                  });
+
+                  const mediaUrl = await s3Service.getObjectUrl(fullName);
+
+                  messageRaw.message.mediaUrl = mediaUrl;
+
+                  await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
+                }
               }
-
-              const { buffer, mediaType, fileName, size } = media;
-
-              const mimetype = mimeTypes.lookup(fileName).toString();
-
-              const fullName = join(
-                `${this.instance.id}`,
-                messageRaw.key.remoteJid,
-                `${messageRaw.key.id}`,
-                mediaType,
-                fileName,
-              );
-
-              await s3Service.uploadFile(fullName, buffer, size.fileLength?.low, { 'Content-Type': mimetype });
-
-              await this.prismaRepository.media.create({
-                data: { messageId: msg.id, instanceId: this.instanceId, type: mediaType, fileName: fullName, mimetype },
-              });
-
-              const mediaUrl = await s3Service.getObjectUrl(fullName);
-
-              messageRaw.message.mediaUrl = mediaUrl;
-
-              await this.prismaRepository.message.update({ where: { id: msg.id }, data: messageRaw });
             }
           } catch (error) {
             this.logger.error(['Error on upload file to minio', error?.message, error?.stack]);


### PR DESCRIPTION
## Problem

On the Baileys channel, media **sent from the phone linked to the instance** (`fromMe`, LID addressing) does not emit `MESSAGES_UPSERT` when `S3_ENABLED=true`. The message is persisted and status updates are emitted, but the event carrying the content never reaches the webhook consumer.

Text from the same phone works. Media **received** from the contact works. Media sent through the API works. For any consumer (CRM, chatbot, archiver) this is a silent drop — no error, no retry.

## Root cause

`src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts`. The S3 upload block uses `return` to skip the upload, but it sits **before** `sendDataWebhook(Events.MESSAGES_UPSERT, ...)` — so skipping the upload drops the webhook with it. And `return`, not `continue`, inside `for (const received of messages)` aborts the whole handler.

The branch that fires, captured with `LOG_LEVEL` including `VERBOSE`:

```
[messages.upsert] key: {"remoteJid":"…@lid","remoteJidAlt":"…@s.whatsapp.net","fromMe":true,"addressingMode":"lid",…}
Message contains only messageContextInfo, skipping media processing
No valid media to upload (messageContextInfo only), skipping MinIO
   <- handler exits here; sendDataWebhook is never reached
```

`getBase64FromMediaMessage` unwraps `MessageSubtype`, replacing the whole body with the wrapper's inner message; for these echoes only `messageContextInfo` is left, it returns `null`, and `if (!media) return;` ends the handler.

The video branch `if (isVideo && !S3.SAVE_VIDEO) return` is reachable the same way — `S3_SAVE_VIDEO` defaults to `false` and is not in `.env.example`, so it fires on every video in any S3-enabled install that did not opt in.

## Regression boundary

| version | code | webhook |
| --- | --- | --- |
| `2.3.6` | `throw 'The message is messageContextInfo'` | caught by the `catch` below, flow continued → **emitted** |
| `2.3.7` → `main`, `develop`, `2.4.0-rc2` | `return null` + `if (!media) return;` | **dropped** |

## Evidence

Production, 8 instances, one day, ~5k media messages. Outbound messages delivered live by the webhook vs. recovered minutes later by an out-of-band reconciliation sweep:

| type | before | after this patch |
| --- | --- | --- |
| audio | 83 live / **1904 recovered** | 15 live / **0** |
| image | 96 live / **308 recovered** | 5 live / **0** |
| document | 99 live / **156 recovered** | 3 live / **0** |
| sticker | 0 live / **35 recovered** | 1 live / **0** |
| text | 4686 live / 6 | unchanged |

- **2180** occurrences of `No valid media to upload` in one day across the 8 instances
- **zero** `Error on upload file to minio` — the upload was not failing, it was never attempted
- sampled on one instance: **343 of 343** of those keys had `addressingMode: "lid"` and `fromMe: true`

## Fix

Restructure both S3 blocks so they skip **only the upload**, never the handler: no `return`/`continue` inside the block, no `throw` for control flow, webhook always emitted. Behaviour unchanged when the upload succeeds.

- `messages.upsert` (receive path) — dropped `sendDataWebhook(Events.MESSAGES_UPSERT)`. This is the reported case.
- `sendMessageWithTyping` (API send path) — the same `if (!media) return` also skipped `sendDataWebhook(Events.SEND_MESSAGE)` **and** the closing `return messageRaw`, so `POST /message/sendMedia` responded empty.

`continue` would not fix it: it skips to the next message in the batch and drops the webhook just the same.

## Verification

Applied to a 2.3.6-based deployment carrying the identical block, `tsc --noEmit` clean, built and rolled out across 8 production instances. The before/after column above is the same day, either side of that rollout.

## Related

- #2684 — same fix, proposed 2026-08-12, still open. That PR notes its environment ran with `LOG_LEVEL=info`, so the branch taken by non-video media was not instrumented; this PR supplies that instrumentation, the regression boundary and the before/after measurement. Happy to close this one in favour of it — what matters is that the fix lands.
- #2396 — the same symptom reported 2026-01-29 with these exact two log lines, closed as `not_planned` during backlog triage on 2026-05-19 rather than fixed; users confirmed it again on 2026-05-21 and 2026-07-01. Worth reopening.
- #1872 — `@lid` vs `@jid` umbrella.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Prevent optional S3 media processing from terminating Baileys message handlers before webhook delivery and response completion.

Bug Fixes:
- Ensure Baileys message-upsert webhooks are emitted when media cannot be uploaded to S3 or video uploads are disabled.
- Ensure API media sends still emit their webhook and return the persisted message when S3 media processing is skipped.

Enhancements:
- Decouple webhook delivery and message handling from optional S3 media upload processing.