### PR TITLE
fix(baileys): pass quoted to sendMessageWithTyping in audioWhatsapp

### DIFF
--- a/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
+++ b/src/api/integrations/channel/whatsapp/whatsapp.baileys.service.ts
@@ -3224,7 +3224,7 @@ export class BaileysStartupService extends ChannelStartupService {
         const result = this.sendMessageWithTyping<AnyMessageContent>(
           data.number,
           { audio: convert, ptt: true, mimetype: 'audio/ogg; codecs=opus' },
-          { presence: 'recording', delay: data?.delay },
+          { presence: 'recording', delay: data?.delay, quoted: data?.quoted },
           isIntegration,
         );
 
@@ -3241,7 +3241,7 @@ export class BaileysStartupService extends ChannelStartupService {
         ptt: true,
         mimetype: 'audio/ogg; codecs=opus',
       },
-      { presence: 'recording', delay: data?.delay },
+      { presence: 'recording', delay: data?.delay, quoted: data?.quoted },
       isIntegration,
     );
   }


### PR DESCRIPTION
## Summary

- **Bug:** `audioWhatsapp` in `whatsapp.baileys.service.ts` was not passing the `quoted` field to `sendMessageWithTyping`, causing audio replies to not render as quoted replies in WhatsApp groups/chats.
- **Root cause:** Both the `encoding=true` (base64) and `encoding=false` (URL) branches were building the options object as `{ presence: 'recording', delay: data?.delay }` — missing `quoted: data?.quoted`.
- **Impact:** Any API consumer sending `POST /message/sendWhatsAppAudio` with a `quoted` field would get the audio delivered, but without the quoted reply context info. Text messages (`sendText`) worked correctly because `textMessage` already passed `quoted`.

## Fix

Added `quoted: data?.quoted` to the options object in both branches of `audioWhatsapp`, matching the behavior already implemented by:
- `textMessage` (same file)
- `audioWhatsapp` in `evolution.channel.service.ts` (already correct)

The `quoted` field was already:
- Present in `SendAudioDto` (via `Metadata` base class)
- Accepted by `audioMessageSchema` (JSONSchema7 validation)

So no DTO or schema changes were needed — only the service layer was silently dropping it.

## Changes

```diff
- { presence: 'recording', delay: data?.delay },
+ { presence: 'recording', delay: data?.delay, quoted: data?.quoted },
```

Applied to both the `encoding=true` and `encoding=false` branches.

#### Test plan

- [x] Send audio with `quoted` via `POST /message/sendWhatsAppAudio` — audio now renders as quoted reply in WhatsApp
- [x] Send audio without `quoted` — still works as normal audio (no regression)
- [x] Send text with `quoted` via `POST /message/sendText` — still works (unchanged)
- [x] Verified `contextInfo` in Evolution API response now includes `stanzaId`, `participant`, and `quotedMessage`

## Summary by Sourcery

Bug Fixes:
- Preserve quoted reply context when sending WhatsApp audio messages through the Baileys integration.